### PR TITLE
Eco 223/use jwt registration in sample app 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,6 @@ jobs:
     
     steps:
       - checkout
-      - run:
-          name: skip is not pr
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUESTS" ]
-            then
-              circleci step halt
-            fi
 
       # Download and cache dependencies
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 # Files for the ART/Dalvik VM
 *.dex
 
-# SampleApp files
-app/src/main/res/values/secret-strings.xml
-
 # Java class files
 *.class
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To setup and run the sample app an authorized apiKey and appId needs to be provi
 In order to receive a test apiKey please contact us.<br/>
 
 Create a local `credential.properties` in the `app` module directory. <br/>
-Add this lines to your local `credential.properties` file of the sample app once you receive your appId and apiKey.<br/>
+Add the lines below to your local `credential.properties` file of the sample app once you receive your appId and apiKey.<br/>
 ```
    APP_ID="YOUR_APP_ID"
    API_KEY="YOUR_API_KEY"

--- a/README.md
+++ b/README.md
@@ -15,67 +15,83 @@ A stellar wallet and account will be created behind the scene for the user. <br/
 ![DEMO](https://user-images.githubusercontent.com/3635216/38100813-0f2c7bc2-3387-11e8-930d-03175842e81e.gif)
 
 
-## Setup
+## Setup sample app
 The sample app (or digital service app) needs to initiate the ecosystem sdk, which interacts with the ecosystem backend service. <br/>
 The ecosystem backend will block unauthorized requests, therefore digital services will have to provide a valid unique apiKey and appID.<br/>
-To setup and run the sample app an authorized apiKey needs to be provided. In order to compile and run the sample app, developers need to add thee apiKey and appID as a string resource. <br/>
+To setup and run the sample app an authorized apiKey and appId needs to be provided.<br/>
 In order to receive a test apiKey please contact us.<br/>
 
-Add this lines to `strings.xml` file of the sample app once you receive your appId and apiKey.<br/>
-```xml
-   <string name="sample_kin_ecosystem_api_key">YOUR_API_KEY</string>
-   <string name="sample_app_id">YOUR_APP_ID</string> 
+Create a local `credential.properties` in the `app` module directory. <br/>
+Add this lines to your local `credential.properties` file of the sample app once you receive your appId and apiKey.<br/>
 ```
+   APP_ID="YOUR_APP_ID"
+   API_KEY="YOUR_API_KEY"
+   RS512_PRIVATE_KEY="YOUR_RS512_PRIVATE_KEY // only applicable when testing JWT on sample app in real use case JWT is created by server side
+   
+```
+The sample app Gradle build loads `credential.properties` setting and use it to create 'SignInData' object used for the registration.
 
-** This is an intermediate API and we are working to streamline the integration process **<br/>
 
 
 ## Integrating 5 minutes SDK within digital service
 As can be seen in the sample app, there are just few step required to integrate the SDK.
 
 1. Add this to your project module's `build.gradle` file.
-  ```gradle
-   repositories {
-       ...
-       maven {
-           url 'https://jitpack.io'
-       }
-   }
-   ```
-2. Add this to the app module's `build.gradle` file.
-  ```gradle
-   dependencies {
-       ...
-       implementation 'com.github.kinfoundation:kin-ecosystem-android-sdk:dev1'
-   }
-
-   ```
-3. Create SignInData object and set userID, appID, apiKey etc.
-  ```java
-   signInData = new SignInData()
-               .signInType(SignInTypeEnum.WHITELIST)
-               .appId(appID)
-               .deviceId(deviceUUID)
-               .userId(userID)
-               .apiKey(apiKey);
-   ```
-4. Initiate SDK when the Application starts calling Kin. The first start will begin the blocakchain wallet and account creation process.
-  ```java
-           try {
-               Kin.start(getApplicationContext(), signInData);
-           } catch (InitializeException e) {
-               //
+      ```gradle
+       repositories {
+           ...
+           maven {
+               url 'https://jitpack.io'
            }
+       }
    ```
-5. Launch the marketplace experience.
-  ```java
-       try {
-           Kin.launchMarketplace(MainActivity.this);
-            System.out.println("Public address : " + Kin.getPublicAddress());
-            } catch (TaskFailedException e) {
-              //
-        }
-   ```
+1. Add this to the app module's `build.gradle` file.
+      ```gradle
+       dependencies {
+           ...
+           implementation 'com.github.kinfoundation:kin-ecosystem-android-sdk:dev1'
+       }
+    
+       ```
+1. Create SignInData object and set userID, appID, apiKey etc.
+
+    1. Option 1 - Should be use only for first time rapid integration and internal testing.
+    
+          ```java
+                signInData = new SignInData()
+                     .signInType(SignInTypeEnum.WHITELIST)
+                     .appId("appID")
+                     .deviceId("deviceUUID")
+                     .userId("userID"")
+                     .apiKey("apiKey");
+         ```
+    1. Option 2 - recommended integration using JWT token signed by digital service server side.     
+        
+          ```java
+                signInData = new SignInData()
+                      .signInType(SignInTypeEnum.JWT)
+                      .jwt("jwt")
+                      .deviceId("deviceUUID")
+          ```
+         JWT spec can be found at [ecosystem-api repository](https://github.com/kinfoundation/ecosystem-api)
+   
+1. Initiate SDK when the Application starts calling Kin. The first start will begin the blocakchain wallet and account creation process.
+      ```java
+               try {
+                   Kin.start(getApplicationContext(), signInData);
+               } catch (InitializeException e) {
+                   //
+               }
+      ```
+1. Launch the marketplace experience.
+      ```java
+           try {
+               Kin.launchMarketplace(MainActivity.this);
+                System.out.println("Public address : " + Kin.getPublicAddress());
+                } catch (TaskFailedException e) {
+                  //
+            }
+      ```
    
 ## License
 The kin-ecosystem-android-sdk library is licensed under [MIT license](LICENSE.md).

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+credential.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,15 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
+        loadCredential()
+        buildConfigField "String", "SAMPLE_APP_ID", credentialProperties.getProperty("APP_ID")
+        buildConfigField "String", "SAMPLE_API_KEY", credentialProperties.getProperty("API_KEY")
+        buildConfigField "String", "RS512_PRIVATE_KEY", credentialProperties.getProperty("RS512_PRIVATE_KEY")
     }
 
     buildTypes {
         release {
             minifyEnabled false
-
         }
     }
 }
@@ -28,10 +31,31 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     api project(':kin-ecosystem-sdk')
-
+    implementation 'io.jsonwebtoken:jjwt:0.9.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+}
+
+def loadCredential() {
+    def credentialPropertiesFile = project.file("credential.properties")
+    def credentialProperties = new Properties()
+
+    if (credentialPropertiesFile.exists()) {
+        credentialProperties.load(new FileInputStream(credentialPropertiesFile))
+    }
+
+    if (!credentialProperties.containsKey("APP_ID")) {
+        credentialProperties.put("APP_ID", '"No appId, please add credential.properties"')
+    }
+    if (!credentialProperties.containsKey("API_KEY")) {
+        credentialProperties.put("API_KEY", '"No apiKey, please add credential.properties"')
+    }
+    if (!credentialProperties.containsKey("RS512_PRIVATE_KEY")) {
+        credentialProperties.put("RS512_PRIVATE_KEY", '"No JWT private key, please add credential.properties"')
+    }
+
+    ext.credentialProperties = credentialProperties
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }
 
+
 def loadCredential() {
     def credentialPropertiesFile = project.file("credential.properties")
     def credentialProperties = new Properties()

--- a/app/src/main/java/com/ecosystem/kin/app/App.java
+++ b/app/src/main/java/com/ecosystem/kin/app/App.java
@@ -13,7 +13,16 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         try {
-            SignInData signInData = SignInRepo.getSignInData(this);
+/*            //Use whitelist signing data for small scale testing
+            SignInData signInData = SignInRepo.getWhitelistSignInData(this);*/
+
+            /*
+            * SignInData should be created with registration JWT {see https://jwt.io/} created securely by server side
+            * In the the this example 'SignInRepo.getJWTSignInData' receive an empty JWT String and the sample app generate the JWT locally.
+            * DO NOT!!!! use this approach in your real app.
+            * */
+
+            SignInData signInData = SignInRepo.getJWTSignInData(this, "");
             Kin.start(getApplicationContext(), signInData);
         } catch (InitializeException e) {
             e.printStackTrace();

--- a/app/src/main/java/com/ecosystem/kin/app/App.java
+++ b/app/src/main/java/com/ecosystem/kin/app/App.java
@@ -1,6 +1,7 @@
 package com.ecosystem.kin.app;
 
 import android.app.Application;
+import android.support.annotation.NonNull;
 import com.ecosystem.kin.app.model.SignInRepo;
 import com.kin.ecosystem.Kin;
 import com.kin.ecosystem.exception.InitializeException;
@@ -9,23 +10,41 @@ import com.kin.ecosystem.network.model.SignInData;
 
 public class App extends Application {
 
+    private static final boolean IS_JWT = true;
+
     @Override
     public void onCreate() {
         super.onCreate();
-        try {
-/*            //Use whitelist signing data for small scale testing
-            SignInData signInData = SignInRepo.getWhitelistSignInData(this);*/
 
+        SignInData signInData;
+
+        if(IS_JWT) {
             /*
             * SignInData should be created with registration JWT {see https://jwt.io/} created securely by server side
-            * In the the this example 'SignInRepo.getJWTSignInData' receive an empty JWT String and the sample app generate the JWT locally.
+            * In the the this example 'SignInRepo.getJWTSignInData' receive an empty/null JWT String and the sample app generate the JWT locally.
             * DO NOT!!!! use this approach in your real app.
             * */
+            signInData = SignInRepo.getJWTSignInData(this, null);
+        } else {
+            //Use whitelist signing data for small scale testing
+            signInData = SignInRepo.getWhitelistSignInData(this, getAppId(), getApiKey());
+        }
 
-            SignInData signInData = SignInRepo.getJWTSignInData(this, "");
+        try {
             Kin.start(getApplicationContext(), signInData);
         } catch (InitializeException e) {
             e.printStackTrace();
         }
     }
+
+    @NonNull
+    private static String getAppId() {
+        return BuildConfig.SAMPLE_APP_ID;
+    }
+
+    @NonNull
+    private static String getApiKey() {
+        return BuildConfig.SAMPLE_API_KEY;
+    }
+
 }

--- a/app/src/main/java/com/ecosystem/kin/app/model/SignInRepo.java
+++ b/app/src/main/java/com/ecosystem/kin/app/model/SignInRepo.java
@@ -2,9 +2,22 @@ package com.ecosystem.kin.app.model;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import com.ecosystem.kin.app.R;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import android.util.Base64;
+import com.ecosystem.kin.app.BuildConfig;
 import com.kin.ecosystem.network.model.SignInData;
 import com.kin.ecosystem.network.model.SignInData.SignInTypeEnum;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
 import java.util.UUID;
 
 public class SignInRepo {
@@ -12,33 +25,109 @@ public class SignInRepo {
     private final static String USER_PREFERENCE_FILE_KEY = "USER_PREFERENCE_FILE_KEY";
     private final static String USER_UUID_KEY = "USER_UUID_KEY";
     private static final String DEVICE_UUID_KEY = "DEVICE_UUID_KEY";
+    private static final long MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
 
-    public static SignInData getSignInData(Context context) {
-        SignInData signInData;
-        SharedPreferences sharedPreferences = context
-            .getSharedPreferences(USER_PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
-        String userID = sharedPreferences.getString(USER_UUID_KEY, null);
+
+    public static SignInData getWhitelistSignInData(Context context) {
+        SignInData signInData = createSignInDataWithDeviceID(context);
+        signInData
+            .signInType(SignInTypeEnum.WHITELIST)
+            .appId(getAppId())
+            .userId(getUserId(context))
+            .apiKey(getApiKey());
+        return signInData;
+    }
+
+    public static SignInData getJWTSignInData(Context context, String jwt) {
+
+        SignInData signInData = createSignInDataWithDeviceID(context);
+        signInData.signInType(SignInTypeEnum.JWT);
+
+        if (TextUtils.isEmpty(jwt)) {
+            signInData.jwt(generateExampleJWT(context));
+        } else {
+            signInData.jwt(jwt);
+        }
+        return signInData;
+    }
+
+    private static SignInData createSignInDataWithDeviceID(Context context) {
+
+        SignInData signInData = new SignInData();
+
+        SharedPreferences sharedPreferences = getSharedPreferences(context);
+
         String deviceUUID = sharedPreferences.getString(DEVICE_UUID_KEY, null);
         if (deviceUUID == null) {
             deviceUUID = UUID.randomUUID().toString();
             sharedPreferences.edit().putString(DEVICE_UUID_KEY, deviceUUID).apply();
         }
+        signInData.deviceId(deviceUUID);
+        return signInData;
+    }
+
+    @NonNull
+    private static String getAppId() {
+        return BuildConfig.SAMPLE_APP_ID;
+    }
+
+    @NonNull
+    private static String getApiKey() {
+        return BuildConfig.SAMPLE_API_KEY;
+    }
+
+    @NonNull
+    private static String getPrivateKeyForJWT() {
+        return BuildConfig.RS512_PRIVATE_KEY;
+    }
+
+    private static SharedPreferences getSharedPreferences(Context context) {
+        return context
+            .getSharedPreferences(USER_PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
+    }
+
+    private static String getUserId(Context context) {
+        SharedPreferences sharedPreferences = getSharedPreferences(context);
+        String userID = sharedPreferences.getString(USER_UUID_KEY, null);
         if (userID == null) {
             userID = UUID.randomUUID().toString();
             sharedPreferences.edit().putString(USER_UUID_KEY, userID).apply();
         }
-        String apiKey = context.getResources().getString(R.string.sample_kin_ecosystem_api_key);
-        String appID = context.getResources().getString(R.string.sample_app_id);
-
-        signInData = new SignInData()
-            .signInType(SignInTypeEnum.WHITELIST)
-            .appId(appID)
-            .deviceId(deviceUUID)
-            .userId(userID)
-            .apiKey(apiKey);
-
-        return signInData;
+        return userID;
     }
 
+    private static String generateExampleJWT(Context context) {
+        String jwt = Jwts.builder()
+            .setHeaderParam("key_id", "1")
+            .setIssuer(getAppId())
+            .setSubject("register")
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + MILLISECONDS_IN_DAY))
+            .claim("user_id", getUserId(context))
+            .claim("api_key", getApiKey())
+            .signWith(SignatureAlgorithm.RS512, getRS512PrivateKey()).compact();
+        return jwt;
+    }
 
+    @Nullable
+    private static PrivateKey getRS512PrivateKey() {
+        PrivateKey privateKey = null;
+        KeyFactory keyFactory;
+
+        byte[] bytes = Base64.decode(getPrivateKeyForJWT(), Base64.NO_WRAP);
+        try {
+            keyFactory = KeyFactory.getInstance("RSA", "BC");
+            privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(bytes));
+
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+
+        } catch (InvalidKeySpecException e) {
+            e.printStackTrace();
+
+        } catch (NoSuchProviderException e) {
+            e.printStackTrace();
+        }
+        return privateKey;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,6 @@
 <resources>
     <string name="app_name">Kin Ecosystem - Sample App</string>
 
-    <string name="sample_kin_ecosystem_api_key">YOUR_API_KEY</string>
-    <string name="sample_app_id">YOUR_APP_ID</string>
-
     <string name="get_balance"><u>Get Balance:</u></string>
     <string name="failed_to_get_balance">Failed to get balance, try again</string>
 </resources>

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -5,6 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import com.kin.ecosystem.base.ObservableData;
+import com.kin.ecosystem.base.Observer;
 import com.kin.ecosystem.data.auth.AuthLocalData;
 import com.kin.ecosystem.data.auth.AuthRemoteData;
 import com.kin.ecosystem.data.auth.AuthRepository;
@@ -49,15 +52,30 @@ public class Kin {
         instance = getInstance();
         appContext = appContext.getApplicationContext(); // use application context to avoid leaks.
         DeviceUtils.init(appContext);
-        initBlockchain(appContext, signInData.getAppId());
+        initBlockchain(appContext);
         registerAccount(appContext, signInData);
         initOfferRepository();
         initOrderRepository(appContext);
+        setAppID();
     }
 
-    private static void initBlockchain(Context context, String appID) throws InitializeException {
-        BlockchainSource.init(context, appID);
+    private static void setAppID() {
+        ObservableData<String> observableData = AuthRepository.getInstance().getAppID();
+        String appID = observableData.getValue();
+        observableData.addObserver(new Observer<String>() {
+            @Override
+            public void onChanged(String appID) {
+                BlockchainSource.getInstance().setAppID(appID);
+            }
+        });
+
+        BlockchainSource.getInstance().setAppID(appID);
     }
+
+    private static void initBlockchain(Context context) throws InitializeException {
+        BlockchainSource.init(context);
+    }
+
 
     private static void registerAccount(@NonNull final Context context, @NonNull final SignInData signInData)
         throws InitializeException {

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/auth/AuthDataSource.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/auth/AuthDataSource.java
@@ -2,12 +2,15 @@ package com.kin.ecosystem.data.auth;
 
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.Callback;
+import com.kin.ecosystem.base.ObservableData;
 import com.kin.ecosystem.network.model.AuthToken;
 import com.kin.ecosystem.network.model.SignInData;
 
 public interface AuthDataSource {
 
     void setSignInData(@NonNull final SignInData signInData);
+
+    ObservableData<String> getAppID();
 
     void setAuthToken(@NonNull final AuthToken authToken);
 

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/auth/AuthRepository.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/auth/AuthRepository.java
@@ -3,11 +3,15 @@ package com.kin.ecosystem.data.auth;
 import static com.kin.ecosystem.util.DateUtil.getDateFromUTCString;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import com.kin.ecosystem.Callback;
+import com.kin.ecosystem.base.ObservableData;
 import com.kin.ecosystem.network.model.AuthToken;
 import com.kin.ecosystem.network.model.SignInData;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Observable;
 
 public class AuthRepository implements AuthDataSource {
 
@@ -18,6 +22,7 @@ public class AuthRepository implements AuthDataSource {
 
     private SignInData cachedSignInData;
     private AuthToken cachedAuthToken;
+    private ObservableData<String> appId = ObservableData.create(null);
 
     private AuthRepository(@NonNull AuthDataSource.Local local, @NonNull AuthDataSource.Remote remote) {
         this.localData = local;
@@ -45,6 +50,12 @@ public class AuthRepository implements AuthDataSource {
         cachedSignInData = signInData;
         localData.setSignInData(signInData);
         remoteData.setSignInData(signInData);
+        postAppID(signInData.getAppId());
+    }
+
+    @Override
+    public ObservableData<String> getAppID() {
+        return appId;
     }
 
     @Override
@@ -148,5 +159,10 @@ public class AuthRepository implements AuthDataSource {
     public void setAuthToken(@NonNull AuthToken authToken) {
         cachedAuthToken = authToken;
         localData.setAuthToken(authToken);
+        postAppID(authToken.getAppID());
+    }
+
+    private void postAppID(@Nullable String appID) {
+        appId.postValue(appID);
     }
 }

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/blockchain/IBlockchainSource.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/blockchain/IBlockchainSource.java
@@ -9,6 +9,11 @@ import java.math.BigDecimal;
 public interface IBlockchainSource {
 
     /**
+     *
+     * @param appID - appID - will be included in the memo for each transaction.
+     */
+    void setAppID(String appID);
+    /**
      * Send transaction to the network
      * @param publicAddress the recipient address
      * @param amount the amount to send

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/network/model/AuthToken.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/network/model/AuthToken.java
@@ -26,6 +26,8 @@ public class AuthToken {
     private Boolean activated = null;
     @SerializedName("expiration_date")
     private String expirationDate = null;
+    @SerializedName("app_id")
+    private String appID = null;
 
     public AuthToken token(String token) {
         this.token = token;
@@ -84,6 +86,14 @@ public class AuthToken {
         this.expirationDate = expirationDate;
     }
 
+    public String getAppID() {
+        return appID;
+    }
+
+    public void setAppID(String appID) {
+        this.appID = appID;
+    }
+
     @Override
     public boolean equals(java.lang.Object o) {
         if (this == o) {
@@ -93,14 +103,16 @@ public class AuthToken {
             return false;
         }
         AuthToken authToken = (AuthToken) o;
-        return Objects.equals(this.token, authToken.token) &&
-            Objects.equals(this.activated, authToken.activated) &&
-            Objects.equals(this.expirationDate, authToken.expirationDate);
+        return this.token.equals(authToken.token) &&
+            this.activated.equals(authToken.activated) &&
+            this.appID.equals(authToken.appID) &&
+            this.expirationDate.equals(authToken.expirationDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(token, activated, expirationDate);
+        return token.hashCode() + activated.hashCode() +
+            expirationDate.hashCode() + appID.hashCode();
     }
 
     @Override
@@ -110,6 +122,7 @@ public class AuthToken {
 
         sb.append("    token: ").append(toIndentedString(token)).append("\n");
         sb.append("    activated: ").append(toIndentedString(activated)).append("\n");
+        sb.append("    appID: ").append(toIndentedString(appID)).append("\n");
         sb.append("    expirationDate: ").append(toIndentedString(expirationDate)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/network/model/SignInData.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/network/model/SignInData.java
@@ -243,6 +243,7 @@ public class SignInData {
         sb.append("    jwt: ").append(toIndentedString(jwt)).append("\n");
         sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
         sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
+        sb.append("    apiKey: ").append(toIndentedString(apiKey)).append("\n");
         sb.append("    deviceId: ").append(toIndentedString(deviceId)).append("\n");
         sb.append("    publicAddress: ").append(toIndentedString(publicAddress)).append("\n");
         sb.append("    signInType: ").append(toIndentedString(signInType)).append("\n");


### PR DESCRIPTION
1. Sample app can now register with whitelist payload or JWT payload.
In the sample app the JWT is generated on client side - this is only for presentation purposes, real app must sign on server side and provide it to client side
2. Get appID from auth token when registering with JWT
3. Run circle CI on every branch (not just PR)
4. Move credentials to credentials.properties local file
5. Update README.md