### PR TITLE
update picasso version to match okhttp3 version + add sample app spec…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,22 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+
+-keepnames class com.fasterxml.jackson.** { *; }
+-keepnames interface com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.databind.**
+
+-keep class org.bouncycastle.** { *; }
+-keepnames class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**
+
+-keep class io.jsonwebtoken.** { *; }
+-keepnames class io.jsonwebtoken.* { *; }
+-keepnames interface io.jsonwebtoken.* { *; }
+-dontwarn io.jsonwebtoken.impl.Base64Codec
+
+
+-dontwarn javax.annotation.**
+
+

--- a/kin-ecosystem-sdk/dependencies.gradle
+++ b/kin-ecosystem-sdk/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
     kinCoreVersion = '0.1.3'
     constraintLayoutVersion = '1.0.2'
     supportVersion = '26.1.0'
-    picassoVersion = '2.5.2'
+    picassoVersion = '2.71828'
     okhttp3Version = '3.9.1'
     gsonVersion = '2.8.2'
     baseRecyclerAdapterVersion = '18191dd'

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/base/BaseViewHolder.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/base/BaseViewHolder.java
@@ -21,7 +21,7 @@ class BaseViewHolder<T> extends com.chad.library.adapter.base.BaseViewHolder<T> 
     protected BaseViewHolder setImageUrlResized(@IdRes int viewId, String imageURL, int width, int height) {
         ImageView view = getView(viewId);
         if (view != null) {
-            Picasso.with(view.getContext())
+            Picasso.get()
                 .load(Uri.parse(imageURL))
                 .transform(new RoundedCornersTransformation(5, 0))
                 .resize(width, height)

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/base/BottomDialog.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/base/BottomDialog.java
@@ -123,7 +123,7 @@ public abstract class BottomDialog<T extends IBottomDialogPresenter> extends Dia
     }
 
     public void setupImage(String image) {
-        Picasso.with(getContext())
+        Picasso.get()
             .load(image)
             .placeholder(R.drawable.kinecosystem_placeholder)
             .fit()


### PR DESCRIPTION
The only non covered Proguard problem was due to using OKhttp within older Picasso version.
The new Picasso version use okhttp3 and covered by underling kin-core Proguard rules.
In addition specific sample app pro guard rules were added to test Proguard release build