### PR TITLE
Add closeMarketplace functionality to the sdk.

### DIFF
--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -1,12 +1,12 @@
 package com.kin.ecosystem;
 
-import static com.kin.ecosystem.exception.ClientException.SDK_NOT_STARTED;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
+
 import com.kin.ecosystem.base.ObservableData;
 import com.kin.ecosystem.base.Observer;
 import com.kin.ecosystem.bi.EventLogger;
@@ -34,11 +34,15 @@ import com.kin.ecosystem.network.model.SignInData;
 import com.kin.ecosystem.network.model.SignInData.SignInTypeEnum;
 import com.kin.ecosystem.splash.view.SplashViewActivity;
 import com.kin.ecosystem.util.ErrorUtil;
+
 import java.util.UUID;
+
 import kin.core.KinClient;
 import kin.core.ServiceProvider;
 import kin.ecosystem.core.util.DeviceUtils;
 import kin.ecosystem.core.util.ExecutorsUtil;
+
+import static com.kin.ecosystem.exception.ClientException.SDK_NOT_STARTED;
 
 
 public class Kin {
@@ -196,6 +200,16 @@ public class Kin {
 		} else {
 			navigateToSplash(activity);
 		}
+	}
+
+	/**
+	 * Closes the Kin Marketplace if it's open
+	 *
+	 * @param context
+	 */
+	public static void closeMarketplace(@NonNull final Context context) {
+		LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(SplashViewActivity.ACTION_CLOSE_SPLASHSCREEN));
+		LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(MarketplaceActivity.ACTION_CLOSE_MARKETPLACE));
 	}
 
 	private static void navigateToSplash(@NonNull final Activity activity) {

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/order/OrderRepository.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/order/OrderRepository.java
@@ -436,7 +436,7 @@ public class OrderRepository implements OrderDataSource {
 				if (response != null) {
 					final List<Order> orders = response.getOrders();
 					if (orders != null && orders.size() > 0) {
-						final Order order = orders.get(orders.size());
+						final Order order = orders.get(orders.size() - 1);
 						OrderConfirmation orderConfirmation = new OrderConfirmation();
 						OrderConfirmation.Status status = OrderConfirmation.Status
 							.fromValue(order.getStatus().getValue());

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
@@ -1,12 +1,17 @@
 package com.kin.ecosystem.marketplace.view;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Toast;
+
 import com.chad.library.adapter.base.BaseRecyclerAdapter;
 import com.chad.library.adapter.base.BaseRecyclerAdapter.OnItemClickListener;
 import com.kin.ecosystem.R;
@@ -24,6 +29,7 @@ import com.kin.ecosystem.network.model.Offer;
 import com.kin.ecosystem.network.model.Offer.OfferType;
 import com.kin.ecosystem.poll.view.PollWebViewActivity;
 import com.kin.ecosystem.poll.view.PollWebViewActivity.PollBundle;
+
 import java.util.List;
 
 
@@ -34,6 +40,16 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
     private SpendRecyclerAdapter spendRecyclerAdapter;
     private EarnRecyclerAdapter earnRecyclerAdapter;
     private OffersEmptyView offersEmptyView;
+
+    public static final String ACTION_CLOSE_MARKETPLACE = "com.kin.ecosystem.marketplace.view.MarketplaceActivity.ACTION_CLOSE_MARKETPLACE";
+    private BroadcastReceiver closeMarketplaceBroadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (ACTION_CLOSE_MARKETPLACE.equals(intent.getAction())) {
+                finish();
+            }
+        }
+    };
 
     @Override
     protected int getLayoutRes() {
@@ -71,6 +87,14 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
     protected void onStart() {
         super.onStart();
         marketplacePresenter.getOffers();
+        LocalBroadcastManager.getInstance(this).registerReceiver(closeMarketplaceBroadcastReceiver, new IntentFilter(ACTION_CLOSE_MARKETPLACE));
+    }
+
+    @Override
+    protected void onPause()
+    {
+        super.onPause();
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(closeMarketplaceBroadcastReceiver);
     }
 
     @Override

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/splash/view/SplashViewActivity.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/splash/view/SplashViewActivity.java
@@ -1,8 +1,12 @@
 package com.kin.ecosystem.splash.view;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -32,6 +36,15 @@ public class SplashViewActivity extends AppCompatActivity implements ISplashView
     private static final float ONE_FLOAT = 1f;
     private Animation fadeIn = new AlphaAnimation(ZERO_FLOAT, ONE_FLOAT);
     private Animation fadeOutLoading = new AlphaAnimation(ONE_FLOAT, ZERO_FLOAT);
+    public static final String ACTION_CLOSE_SPLASHSCREEN = "com.kin.ecosystem.splash.view.ACTION_CLOSE_SPLASHSCREEN";
+    private BroadcastReceiver closeSplashBroadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (ACTION_CLOSE_SPLASHSCREEN.equals(intent.getAction())) {
+                finish();
+            }
+        }
+    };
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -40,6 +53,20 @@ public class SplashViewActivity extends AppCompatActivity implements ISplashView
         attachPresenter(new SplashPresenter(AuthRepository.getInstance(), EventLoggerImpl.getInstance()));
         initViews();
         initAnimations();
+    }
+
+    @Override
+    protected void onStart()
+    {
+        super.onStart();
+        LocalBroadcastManager.getInstance(this).registerReceiver(closeSplashBroadcastReceiver, new IntentFilter(ACTION_CLOSE_SPLASHSCREEN));
+    }
+
+    @Override
+    protected void onPause()
+    {
+        super.onPause();
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(closeSplashBroadcastReceiver);
     }
 
     private void initAnimations() {


### PR DESCRIPTION
This exposes a public ```closeMarketplace``` function on the Kin class to allow callers of
```launchMarketplace ``` a companion method to programatically close it.
e.g. This is useful in cases such as a NativeSpendOffer registered Observer callback.

*Technical Description*
Utilizes Local Broadcast messages and BroadcastReciever's on both the Marcketplace and SplashView activities.