### PR TITLE
change subtitle on empty state + marketpalce recycler empty view crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.31
+SAMPLE_VERSION_NAME=0.0.32
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.0.9
 

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/blockchain/BlockchainSourceImpl.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/data/blockchain/BlockchainSourceImpl.java
@@ -179,7 +179,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 						@Override
 						public void onError(Exception e) {
 							eventLogger.send(SpendTransactionBroadcastToBlockchainFailed.create(e.getMessage(), offerID, orderID));
-							completedPayment.setValue(new Payment(orderID, false, e));
+							completedPayment.postValue(new Payment(orderID, false, e));
 							Log.d(TAG, "sendTransaction onError: " + e.getMessage());
 						}
 					});
@@ -189,7 +189,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 			public void onFailure(OperationFailedException e) {
 				final String errorMessage = "Trustline failed - " + e.getMessage();
 				eventLogger.send(SpendTransactionBroadcastToBlockchainFailed.create(errorMessage, offerID, orderID));
-				completedPayment.setValue(new Payment(orderID, false, e));
+				completedPayment.postValue(new Payment(orderID, false, e));
 				Log.d(TAG, "sendTransaction onError: " + e.getMessage());
 			}
 		});
@@ -352,7 +352,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 					Log.d(TAG,
 						"startPaymentListener onEvent: the orderId: " + orderID + " with memo: " + data.memo());
 					if (orderID != null) {
-						completedPayment.setValue(new Payment(orderID, data.hash().id(), data.amount()));
+						completedPayment.postValue(new Payment(orderID, data.hash().id(), data.amount()));
 						Log.d(TAG, "completedPayment order id: " + orderID);
 					}
 					// UpdateBalance if there is no balance sse open connection.

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -7,7 +7,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.kin.ecosystem.KinCallback;
 import com.kin.ecosystem.base.BasePresenter;
-import com.kin.ecosystem.base.ObservableData;
 import com.kin.ecosystem.base.Observer;
 import com.kin.ecosystem.bi.EventLogger;
 import com.kin.ecosystem.bi.events.BackButtonOnMarketplacePageTapped;
@@ -50,7 +49,6 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private boolean isEarnListEmpty;
 	private boolean isSpendListEmpty;
-
 
 
 	private final Gson gson;
@@ -163,7 +161,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 	}
 
 	private int getSafeIndexEarnEmptyState(final int index) {
-		return isEarnListEmpty? 1 : index;
+		return isEarnListEmpty ? 1 : index;
 	}
 
 	private int getSafeIndexSpendEmptyState(final int index) {

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -156,20 +156,16 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 	}
 
 	private void setEarnEmptyViewIfNeeded() {
-		if (earnList.size() == 0) {
-			isEarnEmpty.postValue(true);
-		}
+		isEarnEmpty.postValue(earnList.size() == 0);
 	}
 
 	private void setSpendEmptyViewIfNeeded() {
-		if (spendList.size() == 0) {
-			isSpendEmpty.postValue(true);
-		}
+		isSpendEmpty.postValue(spendList.size() == 0);
 	}
 
 	private void notifyEarnItemRemoved(int index) {
 		if (view != null) {
-			view.notifyEarnItemRemoved(getSafeIndexEarnEmptyState(index));
+			view.notifyEarnItemRemoved(index);
 		}
 	}
 
@@ -181,7 +177,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private void notifySpendItemRemoved(int index) {
 		if (view != null) {
-			view.notifySpendItemRemoved(getSafeIndexSpendEmptyState(index));
+			view.notifySpendItemRemoved(index);
 		}
 	}
 

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -3,6 +3,7 @@ package com.kin.ecosystem.marketplace.presenter;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.kin.ecosystem.KinCallback;
@@ -35,6 +36,7 @@ import java.util.List;
 
 public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implements IMarketplacePresenter {
 
+	private static final String TAG = "MarketplacePresenter";
 	private static final int NOT_FOUND = -1;
 
 	private static final String EMPTY_SUBTITLE = "Check back tomorrow for more great opportunities";
@@ -77,6 +79,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 		isEarnEmpty.addObserver(getEarnEmptyObserver());
 		isSpendEmpty.addObserver(getSpendEmptyObserver());
 		getCachedOffers();
+		getOffers();
 		listenToPendingOffers();
 		listenToCompletedOrders();
 		eventLogger.send(MarketplacePageViewed.create());
@@ -91,6 +94,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 					if (view != null) {
 						view.updateEarnSubtitle(subtitle);
 						if (value) {
+							Log.d(TAG, "EarnEmptyObserver onChanged:  setEarnEmptyView");
 							view.setEarnEmptyView();
 						}
 					}
@@ -110,6 +114,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 					if (view != null) {
 						view.updateSpendSubtitle(subtitle);
 						if (value) {
+							Log.d(TAG, "SpendEmptyObserver onChanged:  setSpendEmptyView");
 							view.setSpendEmptyView();
 						}
 					}
@@ -180,24 +185,28 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private void notifyEarnItemRemoved(int index) {
 		if (view != null) {
-			view.notifyEarnItemRemoved(getSafeIndexEarnEmptyState(index));
+			Log.d(TAG, "notifyEarnItemRemoved: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isEarnEmpty.getValue());
+			view.notifyEarnItemRemoved(index);
 		}
 	}
 
 	private void notifyEarnItemInserted(int index) {
 		if (view != null) {
+			Log.d(TAG, "notifyEarnItemInserted: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isEarnEmpty.getValue());
 			view.notifyEarnItemInserted(getSafeIndexEarnEmptyState(index));
 		}
 	}
 
 	private void notifySpendItemRemoved(int index) {
 		if (view != null) {
+			Log.d(TAG, "notifySpendItemRemoved: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isSpendEmpty.getValue());
 			view.notifySpendItemRemoved(getSafeIndexSpendEmptyState(index));
 		}
 	}
 
 	private void notifySpendItemInserted(int index) {
 		if (view != null) {
+			Log.d(TAG, "notifySpendItemInserted: " + getSafeIndexSpendEmptyState(index) + " isEmpty= " + isSpendEmpty.getValue());
 			view.notifySpendItemInserted(getSafeIndexSpendEmptyState(index));
 		}
 	}
@@ -225,6 +234,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	@Override
 	public void getOffers() {
+		Log.d(TAG, "getOffers");
 		this.offerRepository.getOffers(new KinCallback<OfferList>() {
 			@Override
 			public void onResponse(OfferList offerList) {
@@ -293,15 +303,15 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private void notifyItemInserted(int index, OfferType offerType) {
 		if (isSpend(offerType)) {
+			notifySpendItemInserted(index);
 			if (isSpendEmpty.getValue() == null || isSpendEmpty.getValue()) {
 				isSpendEmpty.postValue(false);
 			}
-			notifySpendItemInserted(index);
 		} else {
+			notifyEarnItemInserted(index);
 			if (isEarnEmpty.getValue() == null || isEarnEmpty.getValue()) {
 				isEarnEmpty.postValue(false);
 			}
-			notifyEarnItemInserted(index);
 		}
 	}
 

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -3,7 +3,6 @@ package com.kin.ecosystem.marketplace.presenter;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.kin.ecosystem.KinCallback;
@@ -37,10 +36,6 @@ import java.util.List;
 public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implements IMarketplacePresenter {
 
 	private static final int NOT_FOUND = -1;
-
-	private static final String EMPTY_SUBTITLE = "Check back tomorrow for more great opportunities";
-	private static final String EARN_SUBTITLE = "Complete tasks and earn KIN";
-	private static final String SPEND_SUBTITLE = "Use your KIN to enjoy stuff you like";
 
 	private final OfferDataSource offerRepository;
 	private final OrderDataSource orderRepository;
@@ -89,12 +84,8 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 			isEarnEmptyObserver = new Observer<Boolean>() {
 				@Override
 				public void onChanged(Boolean value) {
-					final String subtitle = value ? EMPTY_SUBTITLE : EARN_SUBTITLE;
 					if (view != null) {
-						view.updateEarnSubtitle(subtitle);
-						if (value) {
-							view.setEarnEmptyView();
-						}
+						view.updateEarnSubtitle(value);
 					}
 				}
 			};
@@ -108,12 +99,8 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 			isSpendEmptyObserver = new Observer<Boolean>() {
 				@Override
 				public void onChanged(Boolean value) {
-					final String subtitle = value ? EMPTY_SUBTITLE : SPEND_SUBTITLE;
 					if (view != null) {
-						view.updateSpendSubtitle(subtitle);
-						if (value) {
-							view.setSpendEmptyView();
-						}
+						view.updateSpendSubtitle(value);
 					}
 				}
 			};

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implements IMarketplacePresenter {
 
-	private static final String TAG = "MarketplacePresenter";
 	private static final int NOT_FOUND = -1;
 
 	private static final String EMPTY_SUBTITLE = "Check back tomorrow for more great opportunities";
@@ -94,7 +93,6 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 					if (view != null) {
 						view.updateEarnSubtitle(subtitle);
 						if (value) {
-							Log.d(TAG, "EarnEmptyObserver onChanged:  setEarnEmptyView");
 							view.setEarnEmptyView();
 						}
 					}
@@ -114,7 +112,6 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 					if (view != null) {
 						view.updateSpendSubtitle(subtitle);
 						if (value) {
-							Log.d(TAG, "SpendEmptyObserver onChanged:  setSpendEmptyView");
 							view.setSpendEmptyView();
 						}
 					}
@@ -185,28 +182,24 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private void notifyEarnItemRemoved(int index) {
 		if (view != null) {
-			Log.d(TAG, "notifyEarnItemRemoved: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isEarnEmpty.getValue());
-			view.notifyEarnItemRemoved(index);
+			view.notifyEarnItemRemoved(getSafeIndexEarnEmptyState(index));
 		}
 	}
 
 	private void notifyEarnItemInserted(int index) {
 		if (view != null) {
-			Log.d(TAG, "notifyEarnItemInserted: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isEarnEmpty.getValue());
 			view.notifyEarnItemInserted(getSafeIndexEarnEmptyState(index));
 		}
 	}
 
 	private void notifySpendItemRemoved(int index) {
 		if (view != null) {
-			Log.d(TAG, "notifySpendItemRemoved: " + getSafeIndexEarnEmptyState(index) + " isEmpty= " + isSpendEmpty.getValue());
 			view.notifySpendItemRemoved(getSafeIndexSpendEmptyState(index));
 		}
 	}
 
 	private void notifySpendItemInserted(int index) {
 		if (view != null) {
-			Log.d(TAG, "notifySpendItemInserted: " + getSafeIndexSpendEmptyState(index) + " isEmpty= " + isSpendEmpty.getValue());
 			view.notifySpendItemInserted(getSafeIndexSpendEmptyState(index));
 		}
 	}
@@ -234,7 +227,6 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	@Override
 	public void getOffers() {
-		Log.d(TAG, "getOffers");
 		this.offerRepository.getOffers(new KinCallback<OfferList>() {
 			@Override
 			public void onResponse(OfferList offerList) {

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
@@ -35,5 +35,9 @@ public interface IMarketplaceView extends IBaseView<MarketplacePresenter> {
 
     void setSpendEmptyView();
 
+    void updateEarnSubtitle(String subtitle);
+
+    void updateSpendSubtitle(String subtitle);
+
     void navigateBack();
 }

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
@@ -31,13 +31,9 @@ public interface IMarketplaceView extends IBaseView<MarketplacePresenter> {
 
     void showSomethingWentWrong();
 
-    void setEarnEmptyView();
+    void updateEarnSubtitle(boolean isEmpty);
 
-    void setSpendEmptyView();
-
-    void updateEarnSubtitle(String subtitle);
-
-    void updateSpendSubtitle(String subtitle);
+    void updateSpendSubtitle(boolean isEmpty);
 
     void navigateBack();
 }

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 import com.chad.library.adapter.base.BaseRecyclerAdapter;
 import com.chad.library.adapter.base.BaseRecyclerAdapter.OnItemClickListener;
@@ -31,6 +32,8 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
 
     private IMarketplacePresenter marketplacePresenter;
 
+    private TextView spendSubTitle;
+    private TextView earnSubTitle;
     private SpendRecyclerAdapter spendRecyclerAdapter;
     private EarnRecyclerAdapter earnRecyclerAdapter;
     private OffersEmptyView spendEmptyView;
@@ -82,6 +85,9 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
 
     @Override
     protected void initViews() {
+        spendSubTitle = findViewById(R.id.spend_subtitle);
+        earnSubTitle = findViewById(R.id.earn_subtitle);
+
         //Space item decoration for both of the recyclers
         int margin = getResources().getDimensionPixelOffset(R.dimen.kinecosystem_main_margin);
         int space = getResources().getDimensionPixelOffset(R.dimen.kinecosystem_offer_item_list_space);
@@ -206,7 +212,17 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
         spendRecyclerAdapter.setEmptyView(spendEmptyView);
     }
 
-    private OffersEmptyView createEmptyView(OffersEmptyView emptyView) {
+	@Override
+	public void updateEarnSubtitle(String subtitle) {
+        earnSubTitle.setText(subtitle);
+	}
+
+	@Override
+	public void updateSpendSubtitle(String subtitle) {
+        spendSubTitle.setText(subtitle);
+	}
+
+	private OffersEmptyView createEmptyView(OffersEmptyView emptyView) {
         if (emptyView == null) {
             emptyView = new OffersEmptyView(this);
         }

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
@@ -72,12 +72,6 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        marketplacePresenter.getOffers();
-    }
-
-    @Override
     public void attachPresenter(MarketplacePresenter presenter) {
         marketplacePresenter = presenter;
         marketplacePresenter.onAttach(this);

--- a/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
+++ b/kin-ecosystem-sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceActivity.java
@@ -30,14 +30,12 @@ import java.util.List;
 
 public class MarketplaceActivity extends BaseToolbarActivity implements IMarketplaceView {
 
-    private IMarketplacePresenter marketplacePresenter;
+	private IMarketplacePresenter marketplacePresenter;
 
     private TextView spendSubTitle;
     private TextView earnSubTitle;
     private SpendRecyclerAdapter spendRecyclerAdapter;
     private EarnRecyclerAdapter earnRecyclerAdapter;
-    private OffersEmptyView spendEmptyView;
-    private OffersEmptyView earnEmptyView;
 
     @Override
     protected int getLayoutRes() {
@@ -87,31 +85,33 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
         int space = getResources().getDimensionPixelOffset(R.dimen.kinecosystem_offer_item_list_space);
         SpaceItemDecoration itemDecoration = new SpaceItemDecoration(margin, space);
 
-        //Spend Recycler
-        RecyclerView spendRecycler = findViewById(R.id.spend_recycler);
-        spendRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
-        spendRecycler.addItemDecoration(itemDecoration);
-        spendRecyclerAdapter = new SpendRecyclerAdapter(this);
-        spendRecyclerAdapter.bindToRecyclerView(spendRecycler);
-        spendRecyclerAdapter.setOnItemClickListener(new OnItemClickListener() {
-            @Override
-            public void onItemClick(BaseRecyclerAdapter adapter, View view, int position) {
-                marketplacePresenter.onItemClicked(position, OfferType.SPEND);
-            }
-        });
+		//Spend Recycler
+		RecyclerView spendRecycler = findViewById(R.id.spend_recycler);
+		spendRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+		spendRecycler.addItemDecoration(itemDecoration);
+		spendRecyclerAdapter = new SpendRecyclerAdapter(this);
+		spendRecyclerAdapter.bindToRecyclerView(spendRecycler);
+		spendRecyclerAdapter.setOnItemClickListener(new OnItemClickListener() {
+			@Override
+			public void onItemClick(BaseRecyclerAdapter adapter, View view, int position) {
+				marketplacePresenter.onItemClicked(position, OfferType.SPEND);
+			}
+		});
+		spendRecyclerAdapter.setEmptyView(new OffersEmptyView(this));
 
-        //Earn Recycler
-        RecyclerView earnRecycler = findViewById(R.id.earn_recycler);
-        earnRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
-        earnRecycler.addItemDecoration(itemDecoration);
-        earnRecyclerAdapter = new EarnRecyclerAdapter(this);
-        earnRecyclerAdapter.bindToRecyclerView(earnRecycler);
-        earnRecyclerAdapter.setOnItemClickListener(new OnItemClickListener() {
-            @Override
-            public void onItemClick(BaseRecyclerAdapter adapter, View view, int position) {
-                marketplacePresenter.onItemClicked(position, OfferType.EARN);
-            }
-        });
+		//Earn Recycler
+		RecyclerView earnRecycler = findViewById(R.id.earn_recycler);
+		earnRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+		earnRecycler.addItemDecoration(itemDecoration);
+		earnRecyclerAdapter = new EarnRecyclerAdapter(this);
+		earnRecyclerAdapter.bindToRecyclerView(earnRecycler);
+		earnRecyclerAdapter.setOnItemClickListener(new OnItemClickListener() {
+			@Override
+			public void onItemClick(BaseRecyclerAdapter adapter, View view, int position) {
+				marketplacePresenter.onItemClicked(position, OfferType.EARN);
+			}
+		});
+		earnRecyclerAdapter.setEmptyView(new OffersEmptyView(this));
 
         findViewById(R.id.balance_view).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -193,27 +193,16 @@ public class MarketplaceActivity extends BaseToolbarActivity implements IMarketp
         showToast(getString(R.string.kinecosystem_something_went_wrong));
     }
 
-    @Override
-    public void setEarnEmptyView() {
-        earnEmptyView = createEmptyView(earnEmptyView);
-        earnRecyclerAdapter.setEmptyView(earnEmptyView);
-    }
-
-
-    @Override
-    public void setSpendEmptyView() {
-        spendEmptyView = createEmptyView(spendEmptyView);
-        spendRecyclerAdapter.setEmptyView(spendEmptyView);
-    }
-
 	@Override
-	public void updateEarnSubtitle(String subtitle) {
-        earnSubTitle.setText(subtitle);
+	public void updateEarnSubtitle(boolean isEmpty) {
+		earnSubTitle.setText(isEmpty ? R.string.kinecosystem_empty_tomorrow_more_opportunities
+			: R.string.kinecosystem_complete_tasks_and_earn_kin);
 	}
 
 	@Override
-	public void updateSpendSubtitle(String subtitle) {
-        spendSubTitle.setText(subtitle);
+	public void updateSpendSubtitle(boolean isEmpty) {
+		spendSubTitle.setText(isEmpty ? R.string.kinecosystem_empty_tomorrow_more_opportunities
+			: R.string.kinecosystem_use_your_kin_to_enjoy_stuff_you_like);
 	}
 
 	private OffersEmptyView createEmptyView(OffersEmptyView emptyView) {

--- a/kin-ecosystem-sdk/src/main/res/layout/kinecosystem_activity_marketplace.xml
+++ b/kin-ecosystem-sdk/src/main/res/layout/kinecosystem_activity_marketplace.xml
@@ -45,8 +45,7 @@
                 android:id="@+id/earn_subtitle"
                 style="@style/KinecosysSubTitle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/kinecosystem_complete_tasks_and_earn_kin"/>
+                android:layout_height="wrap_content"/>
 
         </LinearLayout>
 
@@ -93,8 +92,7 @@
                 android:id="@+id/spend_subtitle"
                 style="@style/KinecosysSubTitle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/kinecosystem_use_your_kin_to_enjoy_stuff_you_like"/>
+                android:layout_height="wrap_content"/>
         </LinearLayout>
 
 

--- a/kin-ecosystem-sdk/src/main/res/values/strings.xml
+++ b/kin-ecosystem-sdk/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="kinecosystem_kin_balance">Kin Balance</string>
     <string name="kinecosystem_complete_tasks_and_earn_kin">Complete tasks and earn KIN</string>
     <string name="kinecosystem_use_your_kin_to_enjoy_stuff_you_like">Use your KIN to enjoy stuff you like</string>
+    <string name="kinecosystem_empty_tomorrow_more_opportunities">Check back tomorrow for more great opportunities</string>
     <string name="kinecosystem_welcome_to_kin">Welcome to Kin!</string>
     <string name="kinecosystem_welcome_kin_info">Kin puts you at the center of your digital life\nby letting you get recognized and rewarded\nfor the time, energy, ideas, opinions,\nand creativity you share online.</string>
     <string name="kinecosystem_digging_for_gems">Digging for Gems…</string>


### PR DESCRIPTION
- Change subtitle on empty state to something concrete.
- Change all the observable data to post the values on Main Thread instead of set on the same thread
- Fix recycler crash on, updating item after empty state by setting the index of the offer to be 1 instead of 0.