### PR TITLE
Call submitOrder before send transaction to blockchain

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
@@ -1,9 +1,7 @@
 package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
-import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.common.KinCallback;
-import com.kin.ecosystem.common.KinCallbackAdapter;
 import com.kin.ecosystem.common.Observer;
 import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.common.model.Balance;
@@ -14,8 +12,6 @@ import com.kin.ecosystem.core.bi.events.SpendOrderCreationReceived;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.data.blockchain.Payment;
 import com.kin.ecosystem.core.network.ApiException;
-import com.kin.ecosystem.core.network.model.Body;
-import com.kin.ecosystem.core.network.model.Error;
 import com.kin.ecosystem.core.network.model.JWTBodyPaymentConfirmationResult;
 import com.kin.ecosystem.core.network.model.Offer.OfferType;
 import com.kin.ecosystem.core.network.model.OpenOrder;
@@ -25,7 +21,6 @@ import com.kin.ecosystem.core.util.ExecutorsUtil.MainThreadExecutor;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
-import kin.core.TransactionId;
 import kin.core.exception.InsufficientKinException;
 
 class CreateExternalOrderCall extends Thread {

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
@@ -2,11 +2,13 @@ package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.common.Callback;
+import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.KinCallbackAdapter;
 import com.kin.ecosystem.common.Observer;
 import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.common.model.Balance;
 import com.kin.ecosystem.core.bi.EventLogger;
+import com.kin.ecosystem.core.bi.events.SpendOrderCompletionSubmitted;
 import com.kin.ecosystem.core.bi.events.SpendOrderCreationFailed;
 import com.kin.ecosystem.core.bi.events.SpendOrderCreationReceived;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
@@ -28,7 +30,7 @@ import kin.core.exception.InsufficientKinException;
 
 class CreateExternalOrderCall extends Thread {
 
-	private final OrderDataSource.Remote remote;
+	private final OrderDataSource orderRepository;
 	private final BlockchainSource blockchainSource;
 	private final String orderJwt;
 	private final ExternalOrderCallbacks externalOrderCallbacks;
@@ -37,10 +39,10 @@ class CreateExternalOrderCall extends Thread {
 	private OpenOrder openOrder;
 	private MainThreadExecutor mainThreadExecutor = new MainThreadExecutor();
 
-	CreateExternalOrderCall(@NonNull OrderDataSource.Remote remote, @NonNull BlockchainSource blockchainSource,
+	CreateExternalOrderCall(@NonNull OrderDataSource orderRepository, @NonNull BlockchainSource blockchainSource,
 		@NonNull String orderJwt, @NonNull EventLogger eventLogger,
 		@NonNull ExternalOrderCallbacks externalOrderCallbacks) {
-		this.remote = remote;
+		this.orderRepository = orderRepository;
 		this.blockchainSource = blockchainSource;
 		this.orderJwt = orderJwt;
 		this.eventLogger = eventLogger;
@@ -51,13 +53,12 @@ class CreateExternalOrderCall extends Thread {
 	public void run() {
 		try {
 			// Create external order
-			openOrder = remote.createExternalOrderSync(orderJwt);
+			openOrder = orderRepository.createExternalOrderSync(orderJwt);
 			sendOrderCreationReceivedEvent();
-
-			if (openOrder.getOfferType() == OfferType.SPEND) {
+			if (isSpendOrder(openOrder)) {
 				Balance balance = blockchainSource.getBalance();
 				if (balance.getAmount().intValue() < openOrder.getAmount()) {
-					remote.cancelOrderSync(openOrder.getId());
+					orderRepository.cancelOrderSync(openOrder.getId());
 					runOnMainThread(new Runnable() {
 						@Override
 						public void run() {
@@ -69,45 +70,26 @@ class CreateExternalOrderCall extends Thread {
 					return;
 				}
 			}
-
-			runOnMainThread(new Runnable() {
-				@Override
-				public void run() {
-					externalOrderCallbacks.onOrderCreated(openOrder);
-				}
-			});
 		} catch (final ApiException e) {
 			if (isOrderConflictError(e)) {
 				String orderID = extractOrderID(e.getResponseHeaders());
 				getOrder(orderID);
 			} else {
-				sendOrderCreationFailedEvent(e);
+				sendOrderCreationFailedEvent(openOrder, e);
 				onOrderFailed(ErrorUtil.fromApiException(e));
 			}
 			return;
 		}
 
-		if (externalOrderCallbacks instanceof ExternalSpendOrderCallbacks) {
-			blockchainSource.sendTransaction(openOrder.getBlockchainData().getRecipientAddress(),
-				new BigDecimal(openOrder.getAmount()), openOrder.getId(), openOrder.getOfferId());
-
-			runOnMainThread(new Runnable() {
-				@Override
-				public void run() {
-					((ExternalSpendOrderCallbacks) externalOrderCallbacks).onTransactionSent(openOrder);
-				}
-			});
-		}
-
 		//Listen for payments, make sure the transaction succeed.
-		blockchainSource.addPaymentObservable(new Observer<Payment>() {
+		final Observer<Payment> paymentObserver = new Observer<Payment>() {
 			@Override
 			public void onChanged(final Payment payment) {
 				if (isPaymentOrderEquals(payment, openOrder.getId())) {
 					if (payment.isSucceed()) {
 						getOrder(payment.getOrderID());
 					} else {
-						if (externalOrderCallbacks instanceof ExternalSpendOrderCallbacks) {
+						if (isSpendOrder(openOrder)) {
 							runOnMainThread(new Runnable() {
 								@Override
 								public void run() {
@@ -121,10 +103,47 @@ class CreateExternalOrderCall extends Thread {
 					blockchainSource.removePaymentObserver(this);
 				}
 			}
+		};
+		blockchainSource.addPaymentObservable(paymentObserver);
+
+		sendCompletionSubmittedEvent(openOrder);
+		orderRepository.submitOrder(openOrder.getOfferId(), null, openOrder.getId(), new KinCallback<Order>() {
+			@Override
+			public void onResponse(Order response) {
+				if (isSpendOrder(openOrder)) {
+					// Send transaction to the blockchain
+					blockchainSource.sendTransaction(openOrder.getBlockchainData().getRecipientAddress(),
+						new BigDecimal(openOrder.getAmount()), openOrder.getId(), openOrder.getOfferId());
+				}
+			}
+
+			@Override
+			public void onFailure(KinEcosystemException error) {
+				blockchainSource.removePaymentObserver(paymentObserver);
+			}
 		});
 	}
 
-	private void sendOrderCreationFailedEvent(ApiException exception) {
+	private boolean isSpendOrder(OpenOrder openOrder) {
+		return openOrder.getOfferType() == OfferType.SPEND;
+	}
+
+	private void sendCompletionSubmittedEvent(OpenOrder openOrder) {
+		if (openOrder != null && openOrder.getOfferType() != null) {
+			switch (openOrder.getOfferType()) {
+				case SPEND:
+					eventLogger.send(SpendOrderCompletionSubmitted.create(openOrder.getOfferId(), openOrder.getId(), true));
+					break;
+				case EARN:
+					//TODO add event
+					// We don't have event currently
+					break;
+			}
+
+		}
+	}
+
+	private void sendOrderCreationFailedEvent(final OpenOrder openOrder,ApiException exception) {
 		if (openOrder != null && openOrder.getOfferType() != null) {
 			switch (openOrder.getOfferType()) {
 				case SPEND:
@@ -176,24 +195,18 @@ class CreateExternalOrderCall extends Thread {
 	}
 
 	private void getOrder(String orderID) {
-		new GetOrderPollingCall(remote, orderID, new Callback<Order, ApiException>() {
+		orderRepository.getOrder(orderID, new KinCallback<Order>() {
 			@Override
-			public void onResponse(final Order order) {
-				runOnMainThread(new Runnable() {
-					@Override
-					public void run() {
-						externalOrderCallbacks
-							.onOrderConfirmed(((JWTBodyPaymentConfirmationResult) order.getResult()).getJwt(), order);
-					}
-				});
-
+			public void onResponse(Order order) {
+				externalOrderCallbacks
+					.onOrderConfirmed(((JWTBodyPaymentConfirmationResult) order.getResult()).getJwt(), order);
 			}
 
 			@Override
-			public void onFailure(final ApiException e) {
-				onOrderFailed(ErrorUtil.fromApiException(e));
+			public void onFailure(KinEcosystemException e) {
+				onOrderFailed(e);
 			}
-		}).start();
+		});
 	}
 
 	private void onOrderFailed(final KinEcosystemException exception) {
@@ -213,16 +226,12 @@ class CreateExternalOrderCall extends Thread {
 
 	interface ExternalOrderCallbacks {
 
-		void onOrderCreated(OpenOrder openOrder);
-
 		void onOrderConfirmed(String confirmationJwt, Order order);
 
 		void onOrderFailed(KinEcosystemException exception, OpenOrder order);
 	}
 
 	interface ExternalSpendOrderCallbacks extends ExternalOrderCallbacks {
-
-		void onTransactionSent(OpenOrder openOrder);
 
 		void onTransactionFailed(OpenOrder openOrder, KinEcosystemException exception);
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
@@ -8,11 +8,11 @@ import com.kin.ecosystem.core.data.order.OrderDataSource.Remote;
 class ExternalEarnOrderCall extends CreateExternalOrderCall {
 
     ExternalEarnOrderCall(
-        @NonNull Remote remote,
+        @NonNull OrderDataSource orderRepository,
         @NonNull BlockchainSource blockchainSource,
         @NonNull String orderJwt,
         @NonNull EventLogger eventLogger,
         @NonNull ExternalOrderCallbacks externalEarnOrderCallbacks) {
-        super(remote, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks);
+        super(orderRepository, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks);
     }
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
@@ -1,9 +1,8 @@
 package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
-import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.bi.EventLogger;
-import com.kin.ecosystem.core.data.order.OrderDataSource.Remote;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 
 class ExternalEarnOrderCall extends CreateExternalOrderCall {
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
@@ -3,7 +3,6 @@ package com.kin.ecosystem.core.data.order;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.core.bi.EventLogger;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
-import com.kin.ecosystem.core.data.order.OrderDataSource.Remote;
 
 class ExternalSpendOrderCall extends CreateExternalOrderCall {
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
@@ -11,7 +11,7 @@ class ExternalSpendOrderCall extends CreateExternalOrderCall {
 		@NonNull BlockchainSource blockchainSource,
 		@NonNull String orderJwt,
 		@NonNull EventLogger eventLogger,
-		@NonNull ExternalOrderCallbacks externalSpendOrderCallbacks) {
+		@NonNull ExternalSpendOrderCallbacks externalSpendOrderCallbacks) {
 		super(orderRepository, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks);
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
@@ -8,11 +8,11 @@ import com.kin.ecosystem.core.data.order.OrderDataSource.Remote;
 class ExternalSpendOrderCall extends CreateExternalOrderCall {
 
 	ExternalSpendOrderCall(
-		@NonNull Remote remote,
+		@NonNull OrderDataSource orderRepository,
 		@NonNull BlockchainSource blockchainSource,
 		@NonNull String orderJwt,
 		@NonNull EventLogger eventLogger,
-		@NonNull ExternalSpendOrderCallbacks externalSpendOrderCallbacks) {
-		super(remote, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks);
+		@NonNull ExternalOrderCallbacks externalSpendOrderCallbacks) {
+		super(orderRepository, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks);
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/GetOrderPollingCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/GetOrderPollingCall.java
@@ -4,9 +4,9 @@ import android.support.annotation.NonNull;
 import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.common.exception.ClientException;
 import com.kin.ecosystem.core.network.ApiException;
-import com.kin.ecosystem.core.util.ErrorUtil;
 import com.kin.ecosystem.core.network.model.Order;
 import com.kin.ecosystem.core.network.model.Order.Status;
+import com.kin.ecosystem.core.util.ErrorUtil;
 
 class GetOrderPollingCall extends Thread {
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderDataSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderDataSource.java
@@ -24,9 +24,15 @@ public interface OrderDataSource {
     void submitOrder(@NonNull final String offerID, @Nullable String content, @NonNull String orderID,
         final KinCallback<Order> callback);
 
+    void cancelOrderSync(@NonNull final String orderID);
+
     void cancelOrder(@NonNull final String offerID, @NonNull final String orderID, final KinCallback<Void> callback);
 
     ObservableData<OpenOrder> getOpenOrder();
+
+    void getOrder(@NonNull final String orderID,@Nullable final KinCallback<Order> callback);
+
+    OpenOrder createExternalOrderSync(@NonNull final String orderJwt) throws ApiException;
 
     void purchase(String offerJwt, @Nullable final KinCallback<OrderConfirmation> callback);
 
@@ -61,9 +67,9 @@ public interface OrderDataSource {
 
         void cancelOrderSync(@NonNull final String orderID);
 
-        void getOrder(String orderID, Callback<Order, ApiException> callback);
+        void getOrder(@NonNull final String orderID, Callback<Order, ApiException> callback);
 
-        Order getOrderSync(String orderID);
+        Order getOrderSync(@NonNull final String orderID);
 
         OpenOrder createExternalOrderSync(String orderJwt) throws ApiException;
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRemoteData.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRemoteData.java
@@ -199,7 +199,7 @@ public class OrderRemoteData implements OrderDataSource.Remote {
     }
 
     @Override
-    public void getOrder(String orderID, final Callback<Order, ApiException> callback) {
+    public void getOrder(@NonNull final String orderID, final Callback<Order, ApiException> callback) {
         new GetOrderPollingCall(this, orderID, new Callback<Order, ApiException>() {
             @Override
             public void onResponse(final Order result) {
@@ -224,7 +224,7 @@ public class OrderRemoteData implements OrderDataSource.Remote {
     }
 
     @Override
-    public Order getOrderSync(String orderID) {
+    public Order getOrderSync(@NonNull final String orderID) {
         Order order = null;
         try {
             order = ordersApi.getOrder(orderID, "");

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRemoteData.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRemoteData.java
@@ -2,6 +2,7 @@ package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.core.Log;
 import com.kin.ecosystem.core.Logger;
 import com.kin.ecosystem.core.network.ApiCallback;
@@ -14,7 +15,6 @@ import com.kin.ecosystem.core.network.model.OpenOrder;
 import com.kin.ecosystem.core.network.model.Order;
 import com.kin.ecosystem.core.network.model.OrderList;
 import com.kin.ecosystem.core.util.ExecutorsUtil;
-import com.kin.ecosystem.common.Callback;
 import java.util.List;
 import java.util.Map;
 

--- a/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
+++ b/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
@@ -13,24 +13,24 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.Observer;
+import com.kin.ecosystem.common.exception.BlockchainException;
+import com.kin.ecosystem.common.exception.DataNotAvailableException;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
+import com.kin.ecosystem.common.model.Balance;
+import com.kin.ecosystem.common.model.OrderConfirmation;
 import com.kin.ecosystem.core.bi.EventLogger;
 import com.kin.ecosystem.core.bi.events.EarnOrderPaymentConfirmed;
 import com.kin.ecosystem.core.bi.events.SpendOrderCompleted;
 import com.kin.ecosystem.core.bi.events.SpendOrderFailed;
-import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
-import com.kin.ecosystem.common.model.Balance;
-import com.kin.ecosystem.common.model.OrderConfirmation;
 import com.kin.ecosystem.core.data.blockchain.Payment;
-import com.kin.ecosystem.common.exception.BlockchainException;
-import com.kin.ecosystem.common.exception.DataNotAvailableException;
-import com.kin.ecosystem.common.exception.KinEcosystemException;
-import com.kin.ecosystem.core.data.order.OrderDataSource;
-import com.kin.ecosystem.core.data.order.OrderRepository;
+import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.core.network.model.BlockchainData;
 import com.kin.ecosystem.core.network.model.Body;
+import com.kin.ecosystem.core.network.model.Error;
 import com.kin.ecosystem.core.network.model.JWTBodyPaymentConfirmationResult;
 import com.kin.ecosystem.core.network.model.Offer;
 import com.kin.ecosystem.core.network.model.Offer.OfferType;
@@ -47,8 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import com.kin.ecosystem.core.network.ApiException;
-import com.kin.ecosystem.core.network.model.Error;
 import kin.ecosystem.test.base.BaseTestClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -398,7 +396,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		}
 
 		verify(remote, never()).changeOrder(anyString(), any(Body.class), any(Callback.class));
-		verify(remote).getOrder(anyString(), getOrderCapture.capture());
+		verify(remote, times(2)).getOrder(anyString(), getOrderCapture.capture());
 		List<Callback<Order, ApiException>> getOrderCallbackList = getOrderCapture.getAllValues();
 		for (Callback<Order, ApiException> callback : getOrderCallbackList) {
 			callback.onResponse(confirmedOrder);

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/SpendDialogPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/SpendDialogPresenter.java
@@ -125,11 +125,8 @@ class SpendDialogPresenter extends BaseDialogPresenter<ISpendDialog> implements 
 	private void submitAndSendTransaction() {
 		if (openOrder != null) {
 			isSubmitted = true;
-			final String addressee = offer.getBlockchainData().getRecipientAddress();
 			final String orderID = openOrder.getId();
-
 			submitOrder(offer.getId(), orderID);
-			sendTransaction(addressee, amount, orderID);
 		}
 	}
 
@@ -175,16 +172,19 @@ class SpendDialogPresenter extends BaseDialogPresenter<ISpendDialog> implements 
 		blockchainSource.sendTransaction(addressee, amount, orderID, offer.getId());
 	}
 
-	private void submitOrder(String offerID, String orderID) {
+	private void submitOrder(String offerID, final String orderID) {
 		eventLogger.send(SpendOrderCompletionSubmitted.create(offerID, orderID, false));
 		orderRepository.submitOrder(offerID, null, orderID, new KinCallback<Order>() {
             @Override
             public void onResponse(Order response) {
+				final String addressee = offer.getBlockchainData().getRecipientAddress();
+				sendTransaction(addressee, amount, orderID);
 				Logger.log(new Log().withTag(TAG).put(" Submit onResponse", response));
             }
 
             @Override
             public void onFailure(KinEcosystemException exception) {
+            	showToast("Oops something went wrong...");
 				Logger.log(new Log().withTag(TAG).put(" Submit onFailure", exception));
             }
         });


### PR DESCRIPTION
#### Main purpose:
We need to call submitOrder before sending the transaction to the blockchain, so if the transaction is sent before submitOrder, the server might miss the transaction
#### Technical description:
- Moved `sendTransaction` after submitOrder is completed.
