### PR TITLE
BI - spend order completed fired twice

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -295,8 +295,9 @@ public class BlockchainSourceImpl implements BlockchainSource {
 					final String orderID = extractOrderId(data.memo());
 					Logger.log(new Log().withTag(TAG).put("startPaymentListener onEvent: the orderId", orderID)
 						.put("with memo", data.memo()));
-					if (orderID != null) {
-						completedPayment.postValue(toPaymentObj(orderID, data));
+					final String accountPublicAddress = getPublicAddress();
+					if (orderID != null && accountPublicAddress != null) {
+						completedPayment.postValue(PaymentConverter.toPayment(data, orderID, accountPublicAddress));
 						Logger.log(new Log().withTag(TAG).put("completedPayment order id", orderID));
 					}
 					// UpdateBalance if there is no balance sse open connection.
@@ -311,11 +312,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 					}
 				}
 			});
-	}
-
-	private Payment toPaymentObj(final String orderID, PaymentInfo data) {
-		boolean isEarn = data.destinationPublicKey().equals(getPublicAddress());
-		return new Payment(orderID, data.hash().id(), data.amount(), isEarn ? Payment.EARN : Payment.SPEND);
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/Payment.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/Payment.java
@@ -1,6 +1,9 @@
 package com.kin.ecosystem.core.data.blockchain;
 
+import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.math.BigDecimal;
 
 /**
@@ -9,69 +12,88 @@ import java.math.BigDecimal;
  */
 public class Payment {
 
-    /**
-     * Order id that the transaction is related to.
-     */
-    private String orderID;
+	public static final int UNKNOWN = 0x00000000;
+	public static final int EARN = 0x00000001;
+	public static final int SPEND = 0x00000002;
 
-    /**
-     * The transaction id on the blockchain, could be null if the transaction failed.
-     */
-    private @Nullable String transactionID;
+	@IntDef({EARN, SPEND})
+	@Retention(RetentionPolicy.SOURCE)
+	public @interface Type {
 
-    /**
-     * The payment amount was sent / received, could be null id transaction failed.
-     */
-    private @Nullable BigDecimal amount;
+	}
 
-    /**
-     * Determine if the transaction succeeded or not.
-     */
-    private boolean isSucceed;
+	/**
+	 * Order id that the transaction is related to.
+	 */
+	private String orderID;
 
-    /**
-     * Exception from kin-core:
-     */
-    private Exception exception;
+	/**
+	 * The transaction id on the blockchain, could be null if the transaction failed.
+	 */
+	private @Nullable
+	String transactionID;
 
-    public Payment(String orderID, @Nullable String transactionID, @Nullable BigDecimal amount) {
-        this.orderID = orderID;
-        this.transactionID = transactionID;
-        this.amount = amount;
-        this.isSucceed = true;
-    }
+	/**
+	 * The payment amount was sent / received, could be null id transaction failed.
+	 */
+	private @Nullable
+	BigDecimal amount;
 
-    public Payment(String orderID, boolean isSucceed, Exception error) {
-        this.orderID = orderID;
-        this.transactionID = null;
-        this.amount = null;
-        this.isSucceed = isSucceed;
-        this.exception = error;
-    }
+	/**
+	 * Determine if the transaction succeeded or not.
+	 */
+	private boolean isSucceed;
 
-    public String getOrderID() {
-        return orderID;
-    }
+	/**
+	 * Exception from kin-core:
+	 */
+	private Exception exception;
 
-    @Nullable
-    public String getTransactionID() {
-        return transactionID;
-    }
+	/**
+	 * The {@link Type} of payment: EARN, SPEND or UNKNOWN if the payment failed.
+	 */
+	private @Type
+	int type = UNKNOWN;
 
-    @Nullable
-    public BigDecimal getAmount() {
-        return amount;
-    }
+	public Payment(String orderID, @Nullable String transactionID, @Nullable BigDecimal amount, @Type int type) {
+		this.orderID = orderID;
+		this.transactionID = transactionID;
+		this.amount = amount;
+		this.isSucceed = true;
+		this.type = type;
+	}
 
-    public boolean isSucceed() {
-        return isSucceed;
-    }
+	public Payment(String orderID, boolean isSucceed, Exception error) {
+		this.orderID = orderID;
+		this.transactionID = null;
+		this.amount = null;
+		this.isSucceed = isSucceed;
+		this.exception = error;
+	}
 
-    public Exception getException() {
-        return exception;
-    }
+	public String getOrderID() {
+		return orderID;
+	}
 
-	public boolean isEarn() {
-		return amount != null && amount.compareTo(BigDecimal.ZERO) == 1;
+	@Nullable
+	public String getTransactionID() {
+		return transactionID;
+	}
+
+	@Nullable
+	public BigDecimal getAmount() {
+		return amount;
+	}
+
+	public boolean isSucceed() {
+		return isSucceed;
+	}
+
+	public Exception getException() {
+		return exception;
+	}
+
+	public int getType() {
+		return type;
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/Payment.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/Payment.java
@@ -16,7 +16,7 @@ public class Payment {
 	public static final int EARN = 0x00000001;
 	public static final int SPEND = 0x00000002;
 
-	@IntDef({EARN, SPEND})
+	@IntDef({UNKNOWN, EARN, SPEND})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface Type {
 
@@ -63,12 +63,12 @@ public class Payment {
 		this.type = type;
 	}
 
-	public Payment(String orderID, boolean isSucceed, Exception error) {
+	public Payment(String orderID, boolean isSucceed, Exception exception) {
 		this.orderID = orderID;
 		this.transactionID = null;
 		this.amount = null;
 		this.isSucceed = isSucceed;
-		this.exception = error;
+		this.exception = exception;
 	}
 
 	public String getOrderID() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/PaymentConverter.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/PaymentConverter.java
@@ -1,0 +1,14 @@
+package com.kin.ecosystem.core.data.blockchain;
+
+import android.support.annotation.NonNull;
+import kin.core.PaymentInfo;
+
+public class PaymentConverter {
+
+	public static Payment toPayment(@NonNull PaymentInfo paymentInfo, @NonNull String orderID,
+		@NonNull String accountPublicAddress) {
+		boolean isEarn = paymentInfo.destinationPublicKey().equals(accountPublicAddress);
+		return new Payment(orderID, paymentInfo.hash().id(), paymentInfo.amount(),
+			isEarn ? Payment.EARN : Payment.SPEND);
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
@@ -216,7 +216,7 @@ public class OrderRepository implements OrderDataSource {
 	}
 
 	private void sendEarnPaymentConfirmed(Payment payment) {
-		if (payment.isSucceed() && payment.getAmount() != null && payment.isEarn()) {
+		if (payment.isSucceed() && payment.getAmount() != null && payment.getType() == Payment.EARN) {
 			eventLogger.send(EarnOrderPaymentConfirmed.create(payment.getTransactionID(), null, payment.getOrderID()));
 		}
 	}
@@ -246,7 +246,7 @@ public class OrderRepository implements OrderDataSource {
 	}
 
 	private void sendSpendOrderCompleted(Order order) {
-		if (order.getOfferType() == OfferType.SPEND) {
+		if (order.getOfferType() == OfferType.SPEND && order.getOrigin() == Origin.MARKETPLACE) {
 			if (order.getStatus() == Status.COMPLETED) {
 				eventLogger.send(SpendOrderCompleted.create(order.getOfferId(), order.getOrderId(), false));
 			} else {

--- a/core/src/test/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.java
+++ b/core/src/test/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.java
@@ -193,6 +193,7 @@ public class BlockchainSourceImplTest extends BaseTestClass {
 				assertFalse(value.isSucceed());
 				assertEquals(orderID, value.getOrderID());
 				assertEquals(exception, value.getException());
+				assertEquals(Payment.UNKNOWN, value.getType());
 			}
 		});
 

--- a/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
+++ b/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.kin.ecosystem.core.data.order;
 
 import static com.kin.ecosystem.common.exception.BlockchainException.INSUFFICIENT_KIN;
+import static com.kin.ecosystem.core.data.blockchain.Payment.EARN;
+import static com.kin.ecosystem.core.data.blockchain.Payment.SPEND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -36,6 +38,7 @@ import com.kin.ecosystem.core.network.model.Offer;
 import com.kin.ecosystem.core.network.model.Offer.OfferType;
 import com.kin.ecosystem.core.network.model.OpenOrder;
 import com.kin.ecosystem.core.network.model.Order;
+import com.kin.ecosystem.core.network.model.Order.Origin;
 import com.kin.ecosystem.core.network.model.Order.Status;
 import com.kin.ecosystem.core.network.model.OrderList;
 import com.kin.ecosystem.core.network.model.OrderSpendResult.TypeEnum;
@@ -204,7 +207,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(order, orderRepository.getOrderWatcher().getValue());
 
 		when(payment.getAmount()).thenReturn(new BigDecimal(20));
-		when(payment.isEarn()).thenReturn(true);
+		when(payment.getType()).thenReturn(EARN);
 		paymentCapture.getValue().onChanged(payment);
 
 		verify(eventLogger).send(any(EarnOrderPaymentConfirmed.class));
@@ -227,6 +230,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		ArgumentCaptor<Callback<Order, ApiException>> getOrderCapture = ArgumentCaptor.forClass(Callback.class);
 
 		when(order.getOfferType()).thenReturn(OfferType.SPEND);
+		when(order.getOrigin()).thenReturn(Origin.MARKETPLACE);
 
 		// Create Order
 		orderRepository.createOrder(order.getOfferId(), openOrderCallback);
@@ -245,7 +249,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(order, orderRepository.getOrderWatcher().getValue());
 
 		when(payment.getAmount()).thenReturn(new BigDecimal(-20));
-		when(payment.isEarn()).thenReturn(false);
+		when(payment.getType()).thenReturn(SPEND);
 		paymentCapture.getValue().onChanged(payment);
 
 		verify(eventLogger, never()).send(any(EarnOrderPaymentConfirmed.class));
@@ -286,7 +290,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(order, orderRepository.getOrderWatcher().getValue());
 
 		when(payment.getAmount()).thenReturn(new BigDecimal(-20));
-		when(payment.isEarn()).thenReturn(false);
+		when(payment.getType()).thenReturn(SPEND);
 		paymentCapture.getValue().onChanged(payment);
 
 		verify(eventLogger, never()).send(any(EarnOrderPaymentConfirmed.class));

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.41
+SAMPLE_VERSION_NAME=0.0.42
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.1.0
 


### PR DESCRIPTION
#### Main purpose:
BI - event `spend_order_completed` was fired twice because we didn't have the origin of the order. 
I found another bug that we have sent also `earn_order_payment_confirmed` on each payment confirmation and only on earn orders.
#### Technical description:
- Check whether the order origin is MARKETPLACE on `sendSpendOrderCompleted`.
The Native order (Origin: EXTERNAL) is called on its own logic.
- Added to `Payment.java` type filed, and check if this field is EARN on `sendEarnPaymentConfirmed`
#### Tests:
- updated order origin MARKETPLACE where needed
- updated payment type (EARN / SPEND/UNKNOWN)
#### Documentation:
- Added on the source for `Payment -> type` 
