### PR TITLE
bi earn/spend order cration faild blank error msg

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.41
+SAMPLE_VERSION_NAME=0.0.43
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.1.0
 

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/SpendDialogPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/SpendDialogPresenter.java
@@ -19,6 +19,7 @@ import com.kin.ecosystem.common.KinCallbackAdapter;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.data.order.OrderDataSource;
 import com.kin.ecosystem.common.exception.KinEcosystemException;
+import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.marketplace.view.ISpendDialog;
 import com.kin.ecosystem.core.network.model.Offer;
 import com.kin.ecosystem.core.network.model.OfferInfo;
@@ -83,8 +84,12 @@ class SpendDialogPresenter extends BaseDialogPresenter<ISpendDialog> implements 
 			@Override
 			public void onFailure(KinEcosystemException exception) {
 				showToast("Oops something went wrong...");
-				eventLogger
-					.send(SpendOrderCreationFailed.create(exception.getCause().getMessage(), offer.getId(), false));
+				try {
+					String errorMsg = ((ApiException) exception.getCause()).getResponseBody().getMessage();
+					eventLogger.send(SpendOrderCreationFailed.create(errorMsg, offer.getId(), false));
+				} catch (ClassCastException e) {
+					eventLogger.send(SpendOrderCreationFailed.create(exception.getMessage(), offer.getId(), false));
+				}
 			}
 		});
 	}

--- a/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
@@ -1,9 +1,10 @@
 package com.kin.ecosystem.poll.presenter;
 
 import android.support.annotation.NonNull;
-import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.base.BasePresenter;
+import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.Observer;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.core.bi.EventLogger;
 import com.kin.ecosystem.core.bi.events.CloseButtonOnOfferPageTapped;
 import com.kin.ecosystem.core.bi.events.EarnOrderCancelled;
@@ -16,7 +17,7 @@ import com.kin.ecosystem.core.bi.events.EarnOrderCreationRequested;
 import com.kin.ecosystem.core.bi.events.EarnOrderFailed;
 import com.kin.ecosystem.core.bi.events.EarnPageLoaded;
 import com.kin.ecosystem.core.data.order.OrderDataSource;
-import com.kin.ecosystem.common.exception.KinEcosystemException;
+import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.core.network.model.OpenOrder;
 import com.kin.ecosystem.core.network.model.Order;
 import com.kin.ecosystem.poll.view.IPollWebView;
@@ -86,9 +87,12 @@ public class PollWebViewPresenter extends BasePresenter<IPollWebView> implements
 
 			@Override
 			public void onFailure(KinEcosystemException exception) {
-				eventLogger.send(EarnOrderCreationFailed.create(exception.getCause().getMessage(), offerID));
-				if (view != null) {
-					showToast(exception.getMessage());
+				showToast("Oops something went wrong...");
+				try {
+					String errorMsg = ((ApiException) exception.getCause()).getResponseBody().getMessage();
+					eventLogger.send(EarnOrderCreationFailed.create(errorMsg, offerID));
+				} catch (ClassCastException e) {
+					eventLogger.send(EarnOrderCreationFailed.create(exception.getMessage(), offerID));
 				}
 				closeView();
 			}


### PR DESCRIPTION
#### Main purpose:
BI - event `earn_order_creation_failed` was fired with blank error message sometimes.
#### Technical description:
- Send the error message from the server.
