### PR TITLE
BI - update spend events with origin field

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOfferTapped.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOfferTapped.java
@@ -2,11 +2,13 @@
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
-
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 
 /**
@@ -18,14 +20,14 @@ public class SpendOfferTapped implements Event {
     public static final String EVENT_TYPE = "analytics";
 
     // Augmented by script
-    public static SpendOfferTapped create(Double kinAmount, String offerId, String orderId) {
+    public static SpendOfferTapped create(Double kinAmount, String offerId, Origin origin) {
         return new SpendOfferTapped(
             (Common) EventsStore.common(),
             (User) EventsStore.user(),
             (Client) EventsStore.client(),
             kinAmount,
             offerId,
-            orderId);
+            origin);
     }
 
     /**
@@ -89,9 +91,9 @@ public class SpendOfferTapped implements Event {
      * (Required)
      * 
      */
-    @SerializedName("order_id")
+    @SerializedName("origin")
     @Expose
-    private String orderId;
+    private Origin origin;
 
     /**
      * No args constructor for use in serialization
@@ -103,7 +105,7 @@ public class SpendOfferTapped implements Event {
     /**
      * 
      * @param common
-     * @param orderId
+     * @param origin
 
      * @param client
      * @param offerId
@@ -111,14 +113,14 @@ public class SpendOfferTapped implements Event {
 
      * @param user
      */
-    public SpendOfferTapped(Common common, User user, Client client, Double kinAmount, String offerId, String orderId) {
+    public SpendOfferTapped(Common common, User user, Client client, Double kinAmount, String offerId, Origin origin) {
         super();
         this.common = common;
         this.user = user;
         this.client = client;
         this.kinAmount = kinAmount;
         this.offerId = offerId;
-        this.orderId = orderId;
+        this.origin = origin;
     }
 
     /**
@@ -252,8 +254,8 @@ public class SpendOfferTapped implements Event {
      * (Required)
      * 
      */
-    public String getOrderId() {
-        return orderId;
+    public Origin getOrigin() {
+        return origin;
     }
 
     /**
@@ -261,8 +263,47 @@ public class SpendOfferTapped implements Event {
      * (Required)
      * 
      */
-    public void setOrderId(String orderId) {
-        this.orderId = orderId;
+    public void setOrigin(Origin origin) {
+        this.origin = origin;
+    }
+
+    public enum Origin {
+
+        @SerializedName("marketplace")
+        MARKETPLACE("marketplace"),
+        @SerializedName("external")
+        EXTERNAL("external");
+        private final String value;
+        private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+        static {
+            for (Origin c: values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        private Origin(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Origin fromValue(String value) {
+            Origin constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
     }
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCompletionSubmitted.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCompletionSubmitted.java
@@ -1,3 +1,4 @@
+
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
@@ -6,6 +7,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -17,14 +20,16 @@ public class SpendOrderCompletionSubmitted implements Event {
 	public static final String EVENT_TYPE = "log";
 
 	// Augmented by script
-	public static SpendOrderCompletionSubmitted create(String offerId, String orderId, Boolean isNative) {
+	public static SpendOrderCompletionSubmitted create(String offerId, String orderId, Boolean isNative,
+		Origin origin) {
 		return new SpendOrderCompletionSubmitted(
 			(Common) EventsStore.common(),
 			(User) EventsStore.user(),
 			(Client) EventsStore.client(),
 			offerId,
 			orderId,
-			isNative);
+			isNative,
+			origin);
 	}
 
 	/**
@@ -78,6 +83,12 @@ public class SpendOrderCompletionSubmitted implements Event {
 	@SerializedName("is_native")
 	@Expose
 	private Boolean isNative;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("origin")
+	@Expose
+	private Origin origin;
 
 	/**
 	 * No args constructor for use in serialization
@@ -89,6 +100,7 @@ public class SpendOrderCompletionSubmitted implements Event {
 	 *
 	 * @param common
 	 * @param orderId
+	 * @param origin
 
 	 * @param client
 	 * @param offerId
@@ -97,7 +109,7 @@ public class SpendOrderCompletionSubmitted implements Event {
 	 * @param isNative
 	 */
 	public SpendOrderCompletionSubmitted(Common common, User user, Client client, String offerId, String orderId,
-		Boolean isNative) {
+		Boolean isNative, Origin origin) {
 		super();
 		this.common = common;
 		this.user = user;
@@ -105,6 +117,7 @@ public class SpendOrderCompletionSubmitted implements Event {
 		this.offerId = offerId;
 		this.orderId = orderId;
 		this.isNative = isNative;
+		this.origin = origin;
 	}
 
 	/**
@@ -223,6 +236,59 @@ public class SpendOrderCompletionSubmitted implements Event {
 	 */
 	public void setIsNative(Boolean isNative) {
 		this.isNative = isNative;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public Origin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setOrigin(Origin origin) {
+		this.origin = origin;
+	}
+
+	public enum Origin {
+
+		@SerializedName("marketplace")
+		MARKETPLACE("marketplace"),
+		@SerializedName("external")
+		EXTERNAL("external");
+		private final String value;
+		private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+		static {
+			for (Origin c : values()) {
+				CONSTANTS.put(c.value, c);
+			}
+		}
+
+		private Origin(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+		public static Origin fromValue(String value) {
+			Origin constant = CONSTANTS.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationFailed.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationFailed.java
@@ -1,3 +1,4 @@
+
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
@@ -6,6 +7,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -17,14 +20,15 @@ public class SpendOrderCreationFailed implements Event {
 	public static final String EVENT_TYPE = "log";
 
 	// Augmented by script
-	public static SpendOrderCreationFailed create(String errorReason, String offerId, Boolean isNative) {
+	public static SpendOrderCreationFailed create(String errorReason, String offerId, Boolean isNative, Origin origin) {
 		return new SpendOrderCreationFailed(
 			(Common) EventsStore.common(),
 			(User) EventsStore.user(),
 			(Client) EventsStore.client(),
 			errorReason,
 			offerId,
-			isNative);
+			isNative,
+			origin);
 	}
 
 	/**
@@ -78,6 +82,12 @@ public class SpendOrderCreationFailed implements Event {
 	@SerializedName("is_native")
 	@Expose
 	private Boolean isNative;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("origin")
+	@Expose
+	private Origin origin;
 
 	/**
 	 * No args constructor for use in serialization
@@ -89,6 +99,7 @@ public class SpendOrderCreationFailed implements Event {
 	 *
 	 * @param common
 	 * @param errorReason
+	 * @param origin
 
 	 * @param client
 	 * @param offerId
@@ -97,7 +108,7 @@ public class SpendOrderCreationFailed implements Event {
 	 * @param isNative
 	 */
 	public SpendOrderCreationFailed(Common common, User user, Client client, String errorReason, String offerId,
-		Boolean isNative) {
+		Boolean isNative, Origin origin) {
 		super();
 		this.common = common;
 		this.user = user;
@@ -105,6 +116,7 @@ public class SpendOrderCreationFailed implements Event {
 		this.errorReason = errorReason;
 		this.offerId = offerId;
 		this.isNative = isNative;
+		this.origin = origin;
 	}
 
 	/**
@@ -223,6 +235,59 @@ public class SpendOrderCreationFailed implements Event {
 	 */
 	public void setIsNative(Boolean isNative) {
 		this.isNative = isNative;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public Origin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setOrigin(Origin origin) {
+		this.origin = origin;
+	}
+
+	public enum Origin {
+
+		@SerializedName("marketplace")
+		MARKETPLACE("marketplace"),
+		@SerializedName("external")
+		EXTERNAL("external");
+		private final String value;
+		private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+		static {
+			for (Origin c : values()) {
+				CONSTANTS.put(c.value, c);
+			}
+		}
+
+		private Origin(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+		public static Origin fromValue(String value) {
+			Origin constant = CONSTANTS.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationReceived.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationReceived.java
@@ -1,3 +1,4 @@
+
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
@@ -6,6 +7,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -17,14 +20,15 @@ public class SpendOrderCreationReceived implements Event {
 	public static final String EVENT_TYPE = "log";
 
 	// Augmented by script
-	public static SpendOrderCreationReceived create(String offerId, String orderId, Boolean isNative) {
+	public static SpendOrderCreationReceived create(String offerId, String orderId, Boolean isNative, Origin origin) {
 		return new SpendOrderCreationReceived(
 			(Common) EventsStore.common(),
 			(User) EventsStore.user(),
 			(Client) EventsStore.client(),
 			offerId,
 			orderId,
-			isNative);
+			isNative,
+			origin);
 	}
 
 	/**
@@ -78,6 +82,12 @@ public class SpendOrderCreationReceived implements Event {
 	@SerializedName("is_native")
 	@Expose
 	private Boolean isNative;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("origin")
+	@Expose
+	private Origin origin;
 
 	/**
 	 * No args constructor for use in serialization
@@ -89,6 +99,7 @@ public class SpendOrderCreationReceived implements Event {
 	 *
 	 * @param common
 	 * @param orderId
+	 * @param origin
 
 	 * @param client
 	 * @param offerId
@@ -97,7 +108,7 @@ public class SpendOrderCreationReceived implements Event {
 	 * @param isNative
 	 */
 	public SpendOrderCreationReceived(Common common, User user, Client client, String offerId, String orderId,
-		Boolean isNative) {
+		Boolean isNative, Origin origin) {
 		super();
 		this.common = common;
 		this.user = user;
@@ -105,6 +116,7 @@ public class SpendOrderCreationReceived implements Event {
 		this.offerId = offerId;
 		this.orderId = orderId;
 		this.isNative = isNative;
+		this.origin = origin;
 	}
 
 	/**
@@ -223,6 +235,59 @@ public class SpendOrderCreationReceived implements Event {
 	 */
 	public void setIsNative(Boolean isNative) {
 		this.isNative = isNative;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public Origin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setOrigin(Origin origin) {
+		this.origin = origin;
+	}
+
+	public enum Origin {
+
+		@SerializedName("marketplace")
+		MARKETPLACE("marketplace"),
+		@SerializedName("external")
+		EXTERNAL("external");
+		private final String value;
+		private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+		static {
+			for (Origin c : values()) {
+				CONSTANTS.put(c.value, c);
+			}
+		}
+
+		private Origin(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+		public static Origin fromValue(String value) {
+			Origin constant = CONSTANTS.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationRequested.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderCreationRequested.java
@@ -1,3 +1,4 @@
+
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
@@ -6,6 +7,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -17,13 +20,14 @@ public class SpendOrderCreationRequested implements Event {
 	public static final String EVENT_TYPE = "business";
 
 	// Augmented by script
-	public static SpendOrderCreationRequested create(String offerId, Boolean isNative) {
+	public static SpendOrderCreationRequested create(String offerId, Boolean isNative, Origin origin) {
 		return new SpendOrderCreationRequested(
 			(Common) EventsStore.common(),
 			(User) EventsStore.user(),
 			(Client) EventsStore.client(),
 			offerId,
-			isNative);
+			isNative,
+			origin);
 	}
 
 	/**
@@ -71,6 +75,12 @@ public class SpendOrderCreationRequested implements Event {
 	@SerializedName("is_native")
 	@Expose
 	private Boolean isNative;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("origin")
+	@Expose
+	private Origin origin;
 
 	/**
 	 * No args constructor for use in serialization
@@ -81,6 +91,7 @@ public class SpendOrderCreationRequested implements Event {
 	/**
 	 *
 	 * @param common
+	 * @param origin
 
 	 * @param client
 	 * @param offerId
@@ -88,13 +99,15 @@ public class SpendOrderCreationRequested implements Event {
 	 * @param user
 	 * @param isNative
 	 */
-	public SpendOrderCreationRequested(Common common, User user, Client client, String offerId, Boolean isNative) {
+	public SpendOrderCreationRequested(Common common, User user, Client client, String offerId, Boolean isNative,
+		Origin origin) {
 		super();
 		this.common = common;
 		this.user = user;
 		this.client = client;
 		this.offerId = offerId;
 		this.isNative = isNative;
+		this.origin = origin;
 	}
 
 	/**
@@ -199,6 +212,59 @@ public class SpendOrderCreationRequested implements Event {
 	 */
 	public void setIsNative(Boolean isNative) {
 		this.isNative = isNative;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public Origin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setOrigin(Origin origin) {
+		this.origin = origin;
+	}
+
+	public enum Origin {
+
+		@SerializedName("marketplace")
+		MARKETPLACE("marketplace"),
+		@SerializedName("external")
+		EXTERNAL("external");
+		private final String value;
+		private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+		static {
+			for (Origin c : values()) {
+				CONSTANTS.put(c.value, c);
+			}
+		}
+
+		private Origin(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+		public static Origin fromValue(String value) {
+			Origin constant = CONSTANTS.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderFailed.java
+++ b/core/src/main/java/com/kin/ecosystem/core/bi/events/SpendOrderFailed.java
@@ -1,3 +1,4 @@
+
 package com.kin.ecosystem.core.bi.events;
 
 // Augmented by script
@@ -6,6 +7,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.kin.ecosystem.core.bi.Event;
 import com.kin.ecosystem.core.bi.EventsStore;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -17,7 +20,8 @@ public class SpendOrderFailed implements Event {
 	public static final String EVENT_TYPE = "log";
 
 	// Augmented by script
-	public static SpendOrderFailed create(String errorReason, String offerId, String orderId, Boolean isNative) {
+	public static SpendOrderFailed create(String errorReason, String offerId, String orderId, Boolean isNative,
+		Origin origin) {
 		return new SpendOrderFailed(
 			(Common) EventsStore.common(),
 			(User) EventsStore.user(),
@@ -25,7 +29,8 @@ public class SpendOrderFailed implements Event {
 			errorReason,
 			offerId,
 			orderId,
-			isNative);
+			isNative,
+			origin);
 	}
 
 	/**
@@ -85,6 +90,12 @@ public class SpendOrderFailed implements Event {
 	@SerializedName("is_native")
 	@Expose
 	private Boolean isNative;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("origin")
+	@Expose
+	private Origin origin;
 
 	/**
 	 * No args constructor for use in serialization
@@ -97,6 +108,7 @@ public class SpendOrderFailed implements Event {
 	 * @param common
 	 * @param orderId
 	 * @param errorReason
+	 * @param origin
 
 	 * @param client
 	 * @param offerId
@@ -105,7 +117,7 @@ public class SpendOrderFailed implements Event {
 	 * @param isNative
 	 */
 	public SpendOrderFailed(Common common, User user, Client client, String errorReason, String offerId, String orderId,
-		Boolean isNative) {
+		Boolean isNative, Origin origin) {
 		super();
 		this.common = common;
 		this.user = user;
@@ -114,6 +126,7 @@ public class SpendOrderFailed implements Event {
 		this.offerId = offerId;
 		this.orderId = orderId;
 		this.isNative = isNative;
+		this.origin = origin;
 	}
 
 	/**
@@ -246,6 +259,59 @@ public class SpendOrderFailed implements Event {
 	 */
 	public void setIsNative(Boolean isNative) {
 		this.isNative = isNative;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public Origin getOrigin() {
+		return origin;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setOrigin(Origin origin) {
+		this.origin = origin;
+	}
+
+	public enum Origin {
+
+		@SerializedName("marketplace")
+		MARKETPLACE("marketplace"),
+		@SerializedName("external")
+		EXTERNAL("external");
+		private final String value;
+		private final static Map<String, Origin> CONSTANTS = new HashMap<String, Origin>();
+
+		static {
+			for (Origin c : values()) {
+				CONSTANTS.put(c.value, c);
+			}
+		}
+
+		private Origin(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+		public static Origin fromValue(String value) {
+			Origin constant = CONSTANTS.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/CreateExternalOrderCall.java
@@ -129,7 +129,8 @@ class CreateExternalOrderCall extends Thread {
 			switch (openOrder.getOfferType()) {
 				case SPEND:
 					eventLogger
-						.send(SpendOrderCompletionSubmitted.create(openOrder.getOfferId(), openOrder.getId(), true));
+						.send(SpendOrderCompletionSubmitted.create(openOrder.getOfferId(), openOrder.getId(), true,
+							SpendOrderCompletionSubmitted.Origin.EXTERNAL));
 					break;
 				case EARN:
 					//TODO add event
@@ -146,7 +147,8 @@ class CreateExternalOrderCall extends Thread {
 				case SPEND:
 					final Throwable cause = exception.getCause();
 					final String reason = cause != null ? cause.getMessage() : exception.getMessage();
-					eventLogger.send(SpendOrderCreationFailed.create(reason, openOrder.getOfferId(), true));
+					eventLogger.send(SpendOrderCreationFailed
+						.create(reason, openOrder.getOfferId(), true, SpendOrderCreationFailed.Origin.EXTERNAL));
 					break;
 				case EARN:
 					//TODO add event
@@ -162,7 +164,8 @@ class CreateExternalOrderCall extends Thread {
 			switch (openOrder.getOfferType()) {
 				case SPEND:
 					eventLogger.send(SpendOrderCreationReceived
-						.create(openOrder.getOfferId(), openOrder.getId(), true));
+						.create(openOrder.getOfferId(), openOrder.getId(), true,
+							SpendOrderCreationReceived.Origin.EXTERNAL));
 					break;
 				case EARN:
 					break;

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
@@ -257,7 +257,8 @@ public class OrderRepository implements OrderDataSource {
 				if (order.getError() != null) {
 					reason = order.getError().getMessage();
 				}
-				eventLogger.send(SpendOrderFailed.create(reason, order.getOfferId(), order.getOrderId(), false));
+				eventLogger.send(SpendOrderFailed.create(reason, order.getOfferId(), order.getOrderId(), false,
+					SpendOrderFailed.Origin.MARKETPLACE));
 			}
 		}
 	}
@@ -312,7 +313,7 @@ public class OrderRepository implements OrderDataSource {
 
 	@Override
 	public void purchase(String offerJwt, @Nullable final KinCallback<OrderConfirmation> callback) {
-		eventLogger.send(SpendOrderCreationRequested.create("", true));
+		eventLogger.send(SpendOrderCreationRequested.create("", true, SpendOrderCreationRequested.Origin.EXTERNAL));
 		new ExternalSpendOrderCall(this, blockchainSource, offerJwt, eventLogger,
 			new ExternalSpendOrderCallbacks() {
 
@@ -333,7 +334,8 @@ public class OrderRepository implements OrderDataSource {
 						orderId = order.getOrderId();
 						amount = (double) order.getAmount();
 					}
-					eventLogger.send(SpendOrderCompleted.create(offerID, orderId,true, SpendOrderCompleted.Origin.EXTERNAL, amount));
+					eventLogger.send(SpendOrderCompleted
+						.create(offerID, orderId, true, SpendOrderCompleted.Origin.EXTERNAL, amount));
 
 					if (callback != null) {
 						callback.onResponse(createOrderConfirmation(confirmationJwt));
@@ -358,7 +360,8 @@ public class OrderRepository implements OrderDataSource {
 							reason = exception.getMessage();
 						}
 					}
-					eventLogger.send(SpendOrderFailed.create(reason, offerId, orderId, true));
+					eventLogger.send(
+						SpendOrderFailed.create(reason, offerId, orderId, true, SpendOrderFailed.Origin.EXTERNAL));
 
 					if (callback != null) {
 						callback.onFailure(exception);

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.45
+SAMPLE_VERSION_NAME=0.0.46
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.1.0
 

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -16,6 +16,7 @@ import com.kin.ecosystem.core.bi.events.EarnOfferTapped;
 import com.kin.ecosystem.core.bi.events.MarketplacePageViewed;
 import com.kin.ecosystem.core.bi.events.NotEnoughKinPageViewed;
 import com.kin.ecosystem.core.bi.events.SpendOfferTapped;
+import com.kin.ecosystem.core.bi.events.SpendOfferTapped.Origin;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.data.offer.OfferDataSource;
 import com.kin.ecosystem.core.data.order.OrderDataSource;
@@ -335,7 +336,9 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	private void sendSpendOfferTapped(Offer offer) {
 		double amount = (double) offer.getAmount();
-		eventLogger.send(SpendOfferTapped.create(amount, offer.getId(), null));
+		ContentTypeEnum contentType = offer.getContentType();
+		eventLogger.send(SpendOfferTapped.create(amount, offer.getId(),
+			contentType == ContentTypeEnum.EXTERNAL ? Origin.EXTERNAL : Origin.MARKETPLACE));
 	}
 
 	private void nativeSpendOfferClicked(Offer offer, boolean dismissMarketplace) {


### PR DESCRIPTION
#### Main purpose:
We are going to replace `is_native` field with `origin` for consistency.
First, add the `origin` field and later on, we will remove `is_native`.
#### Technical description:
- Copy generated files
- Add `origin` value where is needed
